### PR TITLE
Added volume for sql docker container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE}
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    volumes:
+      - database:/var/lib/mysql
 
   davis:
     build:
@@ -56,3 +58,5 @@ services:
 volumes:
   davis_www:
     name: davis_www
+  database:
+    name: database


### PR DESCRIPTION
Hi @tchapi ,

I'm not a docker expert, but if the drive is missing, the Maria container saves all data within the container. When the container is recreated, all data is gone. This happened to me yesterday.  An update or a backup becomes easier with a volume.
What do you think?

