### PR TITLE
Add LDAPAuthBackend

### DIFF
--- a/.env
+++ b/.env
@@ -52,6 +52,7 @@ IMAP_AUTH_USER_AUTOCREATE=false
 # See https://www.php.net/manual/en/function.ldap-connect for more details
 LDAP_AUTH_URL="ldap://127.0.0.1"
 LDAP_DN_PATTERN="mail=%u"
+LDAP_MAIL_ATTRIBUTE="mail"
 LDAP_AUTH_USER_AUTOCREATE=false
 
 # Do we enable caldav and carddav ?

--- a/.env
+++ b/.env
@@ -40,13 +40,19 @@ ADMIN_PASSWORD=test
 AUTH_REALM=SabreDAV
 
 # Auth Method for the frontend
-# "Basic" or "IMAP"
+# "Basic", "IMAP", or "LDAP"
 AUTH_METHOD=Basic
 
 # In case of IMAP Auth, you must specify the url of the mailbox in the following format {host[:port][/flag1/flag2...]}.
 # See https://www.php.net/manual/en/function.imap-open.php for more details
 IMAP_AUTH_URL=null
 IMAP_AUTH_USER_AUTOCREATE=false
+
+# In case of LDAP Auth, you must specify the url of the LDAP server
+# See https://www.php.net/manual/en/function.ldap-connect for more details
+LDAP_AUTH_URL="ldap://127.0.0.1"
+LDAP_DN_PATTERN="mail=%u"
+LDAP_AUTH_USER_AUTOCREATE=false
 
 # Do we enable caldav and carddav ?
 CALDAV_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Created and maintained (with the help of the community) by [@tchapi](https://git
 
   - PHP > 7.3.0 (with `pdo_mysql` and `intl` extensions), MySQL (or MariaDB), compatible up to PHP 8.1
   - Composer > 2 (_The last release compatible with Composer 1 is [v1.6.2](https://github.com/tchapi/davis/releases/tag/v1.6.2)_)
+  - The [`imap`](https://www.php.net/manual/en/imap.installation.php) and [`ldap`](https://www.php.net/manual/en/ldap.installation.php) PHP extensions if you want to use either authentication methods (_these are not enabled / compiled by default_)
 
 # Installation
 
@@ -69,10 +70,9 @@ c. The auth Realm and method for HTTP auth
 
 ```
 AUTH_REALM=SabreDAV
-AUTH_METHOD=Basic # can be "Basic" or "IMAP"
+AUTH_METHOD=Basic # can be "Basic", "IMAP" or "LDAP"
 ```
-
-> In case you use the `IMAP` auth type, you must specify the auth url (the "mailbox" url) in `IMAP_AUTH_URL`. See https://www.php.net/manual/en/function.imap-open.php for more details.
+> See [the following paragraph](#specific-environment-variables-for-imap-and-ldap-authentication-methods) for more information if you choose either IMAP or LDAP.
 
 d. The global flags to enable CalDAV, CardDAV and WebDAV
 
@@ -102,6 +102,31 @@ g. The Mapbox API key so invitation emails display a nice little static map when
 ```
 MAPBOX_API_KEY=pk.XXXXXXXX
 ```
+
+### Specific environment variables for IMAP and LDAP authentication methods
+
+In case you use the `IMAP` auth type, you must specify the auth url (_the "mailbox" url_) in `IMAP_AUTH_URL`. See https://www.php.net/manual/en/function.imap-open.php for more details.
+
+You should also explicitely define whether you want new authenticated to be created upon login:
+
+```
+IMAP_AUTH_URL="{imap.gmail.com:993/imap/ssl/novalidate-cert}"
+IMAP_AUTH_USER_AUTOCREATE=true # false by default
+```
+
+Same goes for LDAP, where you must specify the LDAP server url, the DN pattern, the Mail attribute, as well as whether you want new authenticated to be created upon login (_like for IMAP_):
+
+```
+LDAP_AUTH_URL="ldap://127.0.0.1"
+LDAP_DN_PATTERN="mail=%u"
+LDAP_MAIL_ATTRIBUTE="mail"
+LDAP_AUTH_USER_AUTOCREATE=true # false by default
+```
+
+> Ex: for [Zimbra LDAP](https://zimbra.github.io/adminguide/latest/#zimbra_ldap_service), you might want to use the `zimbraMailDeliveryAddress` attribute to retrieve the principal user email:
+>    ```
+>    LDAP_MAIL_ATTRIBUTE="zimbraMailDeliveryAddress"
+>    ```
 
 ## Migrating from Baïkal ?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Davis
 [![Publish Docker image](https://github.com/tchapi/davis/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/tchapi/davis/actions/workflows/main.yml)
 [![Latest release][release_badge]][release_link]
 
-A simple, fully translatable admin interface and frontend for `sabre/dav` based on [Symfony 5](https://symfony.com/) and [Bootstrap 4](https://getbootstrap.com/), largely inspired by [Baïkal](https://github.com/sabre-io/Baikal).
+A simple, fully translatable admin interface and frontend for `sabre/dav` based on [Symfony 5](https://symfony.com/) and [Bootstrap 4](https://getbootstrap.com/), initially inspired by [Baïkal](https://github.com/sabre-io/Baikal).
 
 Provides user edition, calendar creation and sharing, address book creation and sharing. The interface is simple and straightforward, responsive, and provides a light and a dark mode.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Provides user edition, calendar creation and sharing, address book creation and 
 
 Easily containerisable (_`Dockerfile` and sample `docker-compose` configuration file provided_).
 
+Supports **Basic authentication**, as well as **IMAP** and **LDAP** (_via external providers_).
+
 Created and maintained (with the help of the community) by [@tchapi](https://github.com/tchapi).
 
 ![Dashboard page](_screenshots/dashboard.png)

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,6 +30,7 @@ services:
         arguments:
             $LDAPAuthUrl: "%env(LDAP_AUTH_URL)%"
             $LDAPDnPattern: "%env(LDAP_DN_PATTERN)%"
+            $LDAPMailAttribute: "%env(LDAP_MAIL_ATTRIBUTE)%"
             $autoCreate: "%env(bool:LDAP_AUTH_USER_AUTOCREATE)%"
 
     # controllers are imported separately to make sure services can be injected

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,12 @@ services:
             $IMAPAuthUrl: "%env(IMAP_AUTH_URL)%"
             $autoCreate: "%env(bool:IMAP_AUTH_USER_AUTOCREATE)%"
 
+    App\Services\LDAPAuth:
+        arguments:
+            $LDAPAuthUrl: "%env(LDAP_AUTH_URL)%"
+            $LDAPDnPattern: "%env(LDAP_DN_PATTERN)%"
+            $autoCreate: "%env(bool:LDAP_AUTH_USER_AUTOCREATE)%"
+
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class
     App\Controller\:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         # These are for IMAP
         libc-client-dev libkrb5-dev \
+        # This one if for LDAP
+        libldap2-dev \
         # There are for php-intl
         zlib1g-dev libicu-dev g++ \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -15,6 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Configure PHP extensions
 RUN docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
     && docker-php-ext-install pdo_mysql
+
+RUN docker-php-ext-configure ldap \
+    && docker-php-ext-install ldap
 
 RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap

--- a/src/Controller/DAVController.php
+++ b/src/Controller/DAVController.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Plugins\DavisIMipPlugin;
 use App\Services\BasicAuth;
 use App\Services\IMAPAuth;
+use App\Services\LDAPAuth;
 use Doctrine\ORM\EntityManagerInterface;
 use PDO;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -20,6 +21,7 @@ class DAVController extends AbstractController
 {
     public const AUTH_BASIC = 'Basic';
     public const AUTH_IMAP = 'IMAP';
+    public const AUTH_LDAP = 'LDAP';
 
     /**
      * Is CalDAV enabled?
@@ -108,7 +110,7 @@ class DAVController extends AbstractController
      */
     protected $server;
 
-    public function __construct(MailerInterface $mailer, BasicAuth $basicAuthBackend, IMAPAuth $IMAPAuthBackend, UrlGeneratorInterface $router, EntityManagerInterface $entityManager, bool $calDAVEnabled = true, bool $cardDAVEnabled = true, bool $webDAVEnabled = false, ?string $inviteAddress = null, ?string $authMethod = null, ?string $authRealm = null, ?string $publicDir = null, ?string $tmpDir = null, ?string $mapboxApiKey = null)
+    public function __construct(MailerInterface $mailer, BasicAuth $basicAuthBackend, IMAPAuth $IMAPAuthBackend, LDAPAuth $LDAPAuthBackend, UrlGeneratorInterface $router, EntityManagerInterface $entityManager, bool $calDAVEnabled = true, bool $cardDAVEnabled = true, bool $webDAVEnabled = false, ?string $inviteAddress = null, ?string $authMethod = null, ?string $authRealm = null, ?string $publicDir = null, ?string $tmpDir = null, ?string $mapboxApiKey = null)
     {
         $this->calDAVEnabled = $calDAVEnabled;
         $this->cardDAVEnabled = $cardDAVEnabled;
@@ -127,6 +129,7 @@ class DAVController extends AbstractController
 
         $this->basicAuthBackend = $basicAuthBackend;
         $this->IMAPAuthBackend = $IMAPAuthBackend;
+        $this->LDAPAuthBackend = $LDAPAuthBackend;
 
         $this->mapboxApiKey = $mapboxApiKey;
 
@@ -160,6 +163,9 @@ class DAVController extends AbstractController
         switch ($this->authMethod) {
             case self::AUTH_IMAP:
                 $authBackend = $this->IMAPAuthBackend;
+                break;
+            case self::AUTH_LDAP:
+                $authBackend = $this->LDAPAuthBackend;
                 break;
             case self::AUTH_BASIC:
             default:

--- a/src/Services/LDAPAuth.php
+++ b/src/Services/LDAPAuth.php
@@ -137,7 +137,7 @@ final class LDAPAuth extends AbstractBasic
                 $email = $username;
 
                 // Try to extract display name and email for this user.
-                // NB: We suppose display name is `cn` and email is `mail`
+                // NB: We suppose display name is `cn` (email is configurable, generally `mail`)
                 $search_results = ldap_read($ldap, $dn, '(objectclass=*)', ['cn', $this->LDAPMailAttribute]);
 
                 if (false !== $search_results) {

--- a/src/Services/LDAPAuth.php
+++ b/src/Services/LDAPAuth.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Services;
+
+use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+use Sabre\DAV\Auth\Backend\AbstractBasic;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class LDAPAuth extends AbstractBasic
+{
+    /**
+     * LDAP server uri.
+     * e.g. ldaps://ldap.example.org.
+     *
+     * @var string
+     */
+    private $LDAPAuthUrl;
+
+    /*
+     * LDAP dn pattern for binding
+     *
+     * %u   - gets replaced by full username
+     * %U   - gets replaced by user part when the
+     *        username is an email address
+     * %d   - gets replaced by domain part when the
+     *        username is an email address
+     * %1-9 - gets replaced by parts of the the domain
+     *        split by '.' in reverse order
+     *        mail.example.org: %1 = org, %2 = example, %3 = mail
+     *
+     * A common pattern is "mail=%u"
+     * @var string
+     */
+    private $LDAPDnPattern;
+
+    /**
+     * Doctrine registry.
+     *
+     * @var \Doctrine\Persistence\ManagerRegistry
+     */
+    private $doctrine;
+
+    /**
+     * Utils class.
+     *
+     * @var Utils
+     */
+    private $utils;
+
+    /**
+     * Should we auto create the user upon successful
+     * login if it does not exist yet.
+     *
+     * @var bool
+     */
+    private $autoCreate;
+
+    /**
+     * Creates the backend object.
+     */
+    public function __construct(ManagerRegistry $doctrine, TranslatorInterface $trans, Utils $utils, string $LDAPAuthUrl, string $LDAPDnPattern, bool $autoCreate)
+    {
+        $this->LDAPAuthUrl = $LDAPAuthUrl;
+        $this->LDAPDnPattern = $LDAPDnPattern;
+        $this->autoCreate = $autoCreate;
+
+        $this->doctrine = $doctrine;
+        $this->utils = $utils;
+    }
+
+    /**
+     * Connects to an LDAP server and tries to authenticate.
+     *
+     * @param string $username
+     * @param string $password
+     *
+     * @return bool
+     */
+    protected function ldapOpen($username, $password)
+    {
+        $success = false;
+
+        try {
+            $ldap = ldap_connect($this->LDAPAuthUrl);
+        } catch (\ErrorException $e) {
+            error_log($e->getMessage());
+        }
+
+        if (!$ldap || !ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3)) {
+            return false;
+        }
+
+        // Extract user and domain from username (in the form user@domain.org)
+        $user_parts = explode('@', $username, 2);
+
+        $ldap_user = $user_parts[0];
+
+        if (count($user_parts) > 1) {
+            $ldap_domain = $user_parts[1];
+        } else {
+            $ldap_domain = '';
+        }
+
+        // Replace common placeholders
+        $dn = str_replace(['%u', '%U', '%d'], [$username, $ldap_user, $ldap_domain], $this->LDAPDnPattern);
+
+        // Replace domain parts
+        $domain_split = array_reverse(explode('.', $ldap_domain));
+        for ($i = 1; $i <= count($domain_split) and $i <= 9; ++$i) {
+            $dn = str_replace('%'.$i, $domain_split[$i - 1], $dn);
+        }
+
+        try {
+            $bind = ldap_bind($ldap, $dn, $password);
+            if ($bind) {
+                $success = true;
+            }
+        } catch (\ErrorException $e) {
+            error_log($e->getMessage());
+            error_log('LDAP Error: '.ldap_error($ldap).' ('.ldap_errno($ldap).')');
+        }
+
+        if (isset($ldap) && $ldap) {
+            ldap_close($ldap);
+        }
+
+        if ($success && $this->autoCreate) {
+            $user = $this->doctrine->getRepository(User::class)->findOneBy(['username' => $username]);
+
+            if (!$user) {
+                // Default fallback values
+                $displayName = $username;
+                $email = $username;
+
+                // Try to extract display name and email for this user.
+                // NB: We suppose display name is `cn` and email is `mail`
+                $search_results = ldap_read($ldap, $dn, '(objectclass=*)', ['cn', 'mail']);
+
+                if (false !== $search_results) {
+                    $entry = ldap_get_entries($ldap, $search_results);
+
+                    if (false !== $entry) {
+                        if (!empty($entry[0]['cn'])) {
+                            $displayName = $entry[0]['cn'][0];
+                        }
+                        if (!empty($entry[0]['mail'])) {
+                            $email = $entry[0]['mail'][0];
+                        }
+                    }
+                }
+
+                $this->utils->createUserWithDefaultObjects($username, $password, $displayName, $email);
+
+                $em = $this->doctrine->getManager();
+                $em->flush();
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * Validates a username and password by trying to authenticate against LDAP.
+     *
+     * @param string $username
+     * @param string $password
+     */
+    protected function validateUserPass($username, $password): bool
+    {
+        return $this->ldapOpen($username, $password);
+    }
+}

--- a/src/Services/LDAPAuth.php
+++ b/src/Services/LDAPAuth.php
@@ -121,10 +121,6 @@ final class LDAPAuth extends AbstractBasic
             error_log('LDAP Error: '.ldap_error($ldap).' ('.ldap_errno($ldap).')');
         }
 
-        if (isset($ldap) && $ldap) {
-            ldap_close($ldap);
-        }
-
         if ($success && $this->autoCreate) {
             $user = $this->doctrine->getRepository(User::class)->findOneBy(['username' => $username]);
 
@@ -155,6 +151,10 @@ final class LDAPAuth extends AbstractBasic
                 $em = $this->doctrine->getManager();
                 $em->flush();
             }
+        }
+
+        if (isset($ldap) && $ldap) {
+          ldap_close($ldap);
         }
 
         return $success;

--- a/src/Services/LDAPAuth.php
+++ b/src/Services/LDAPAuth.php
@@ -154,7 +154,7 @@ final class LDAPAuth extends AbstractBasic
         }
 
         if (isset($ldap) && $ldap) {
-          ldap_close($ldap);
+            ldap_close($ldap);
         }
 
         return $success;

--- a/src/Services/LDAPAuth.php
+++ b/src/Services/LDAPAuth.php
@@ -138,7 +138,12 @@ final class LDAPAuth extends AbstractBasic
 
                 // Try to extract display name and email for this user.
                 // NB: We suppose display name is `cn` (email is configurable, generally `mail`)
-                $search_results = ldap_read($ldap, $dn, '(objectclass=*)', ['cn', $this->LDAPMailAttribute]);
+                try {
+                    $search_results = ldap_read($ldap, $dn, '(objectclass=*)', ['cn', $this->LDAPMailAttribute]);
+                } catch (\Exception $e) {
+                    $search_results = false;
+                    // Probably a "No such object" error, ignore and use available credentials (username)
+                }
 
                 if (false !== $search_results) {
                     $entry = ldap_get_entries($ldap, $search_results);

--- a/src/Services/Utils.php
+++ b/src/Services/Utils.php
@@ -2,7 +2,13 @@
 
 namespace App\Services;
 
+use App\Entity\AddressBook;
+use App\Entity\Calendar;
+use App\Entity\CalendarInstance;
+use App\Entity\Principal;
 use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class Utils
 {
@@ -13,9 +19,11 @@ final class Utils
      */
     private $authRealm;
 
-    public function __construct(?string $authRealm)
+    public function __construct(ManagerRegistry $doctrine, TranslatorInterface $trans, ?string $authRealm)
     {
         $this->authRealm = $authRealm ?? User::DEFAULT_AUTH_REALM;
+        $this->trans = $trans;
+        $this->doctrine = $doctrine;
     }
 
     /**
@@ -24,5 +32,54 @@ final class Utils
     public function hashPassword(string $username, string $password): string
     {
         return md5($username.':'.$this->authRealm.':'.$password);
+    }
+
+    public function createUserWithDefaultObjects(string $username, string $password, string $displayName, string $email)
+    {
+        $user = new User();
+        $user->setUsername($username);
+
+        // Set the password (but hashed beforehand)
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $user->setPassword($hash);
+
+        // Create principal, default calendar and addressbook
+        $principal = new Principal();
+        $principal->setUri(Principal::PREFIX.$username)
+                ->setDisplayName($displayName)
+                ->setEmail($email)
+                ->setIsAdmin(false);
+
+        $calendarInstance = new CalendarInstance();
+        $calendar = new Calendar();
+        $calendarInstance->setPrincipalUri(Principal::PREFIX.$username)
+                ->setUri('default') // No risk of collision since unicity is guaranteed by the new user principal
+                ->setDisplayName($this->trans->trans('default.calendar.title'))
+                ->setDescription($this->trans->trans('default.calendar.description', ['user' => $displayName]))
+                ->setCalendar($calendar);
+
+        // Enable delegation by default
+        $principalProxyRead = new Principal();
+        $principalProxyRead->setUri($principal->getUri().Principal::READ_PROXY_SUFFIX)
+                        ->setIsMain(false);
+
+        $principalProxyWrite = new Principal();
+        $principalProxyWrite->setUri($principal->getUri().Principal::WRITE_PROXY_SUFFIX)
+                        ->setIsMain(false);
+
+        $addressbook = new AddressBook();
+        $addressbook->setPrincipalUri(Principal::PREFIX.$username)
+                ->setUri('default') // No risk of collision since unicity is guaranteed by the new user principal
+                ->setDisplayName($this->trans->trans('default.addressbook.title'))
+                ->setDescription($this->trans->trans('default.addressbook.description', ['user' => $displayName]));
+
+        // Persist all items
+        $em = $this->doctrine->getManager();
+        $em->persist($principalProxyRead);
+        $em->persist($principalProxyWrite);
+        $em->persist($calendarInstance);
+        $em->persist($addressbook);
+        $em->persist($principal);
+        $em->persist($user);
     }
 }

--- a/src/Services/Utils.php
+++ b/src/Services/Utils.php
@@ -19,6 +19,20 @@ final class Utils
      */
     private $authRealm;
 
+    /**
+     * The translation service.
+     *
+     * @var \Symfony\Contracts\Translation\TranslatorInterface
+     */
+    private $trans;
+
+    /**
+     * Doctrine registry.
+     *
+     * @var \Doctrine\Persistence\ManagerRegistry
+     */
+    private $doctrine;
+
     public function __construct(ManagerRegistry $doctrine, TranslatorInterface $trans, ?string $authRealm)
     {
         $this->authRealm = $authRealm ?? User::DEFAULT_AUTH_REALM;


### PR DESCRIPTION
This PR adds the ability to authenticate users via an external LDAP server.

**New env vars**: 

  - `LDAP_AUTH_URL`: the url for the LDAP server
  - `LDAP_DN_PATTERN`: the DN pattern
  - `LDAP_AUTH_USER_AUTOCREATE`: the flag for user auto creation upon login

With `LDAP_AUTH_USER_AUTOCREATE` set to `true`, not previously existing users will be automatically created (as is the case for IMAP auth with the related flag). Display name and email will be derived from the `cn` and `mail` attributes respectively.