### PR TITLE
fix: enable multiplatform docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          uses: linux/amd64,linux/arm64
           file: docker/Dockerfile
           pull: true
           push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,13 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -40,7 +47,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          uses: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           file: docker/Dockerfile
           pull: true
           push: true


### PR DESCRIPTION
This [should](https://github.com/docker/build-push-action/issues/302) fix it.
Can we test the change?