### PR TITLE
Switch to MEDIUMTEXT for card and calendar data

### DIFF
--- a/migrations/Version20231229203515.php
+++ b/migrations/Version20231229203515.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Scale up to MEDIUMTEXT for calendar and card data https://github.com/tchapi/davis/pull/111#issuecomment-1872295498
+ */
+final class Version20231229203515 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Scale up to MEDIUMTEXT for calendar and card data';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration is specific to \'mysql\'. Skipping it is fine.');
+
+        $this->addSql('ALTER TABLE calendarobjects CHANGE calendardata calendardata MEDIUMTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE cards CHANGE carddata carddata MEDIUMTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE schedulingobjects CHANGE calendardata calendardata MEDIUMTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration is specific to \'mysql\'. Skipping it is fine.');
+
+        $this->addSql('ALTER TABLE schedulingobjects CHANGE calendardata calendardata TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE calendarobjects CHANGE calendardata calendardata TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE cards CHANGE carddata carddata TEXT DEFAULT NULL');
+    }
+}

--- a/src/Entity/CalendarObject.php
+++ b/src/Entity/CalendarObject.php
@@ -21,7 +21,8 @@ class CalendarObject
     private $id;
 
     /**
-     * @ORM\Column(name="calendardata", type="text", nullable=true, length=65535)
+     * @ORM\Column(name="calendardata", type="text", nullable=true, length=16777215)
+     * The length corresponds to MEDIUMTEXT in MySQL
      */
     private $calendarData;
 

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -28,7 +28,8 @@ class Card
     private $addressBook;
 
     /**
-     * @ORM\Column(name="carddata", type="text", nullable=true, length=65535)
+     * @ORM\Column(name="carddata", type="text", nullable=true, length=16777215)
+     * The length corresponds to MEDIUMTEXT in MySQL
      */
     private $cardData;
 

--- a/src/Entity/SchedulingObject.php
+++ b/src/Entity/SchedulingObject.php
@@ -27,7 +27,8 @@ class SchedulingObject
     private $principalUri;
 
     /**
-     * @ORM\Column(name="calendardata", type="text", nullable=true, length=65535)
+     * @ORM\Column(name="calendardata", type="text", nullable=true, length=16777215)
+     * The length corresponds to MEDIUMTEXT in MySQL
      */
     private $calendarData;
 


### PR DESCRIPTION
The migration is only needed on MySQL as PostgreSQL and SQLite have unlimited (Well, ~1G) size for TEXT columns