### PR TITLE
Allow setting Symfony's dotenv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ APP_TIMEZONE="Australia/Lord_Howe"
 > ```
 > in your environment file if you wish to use the **actual default timezone of the server**, and not enforcing it. 
 
+
+i. Override the dotenv path
+
+You can override the expected location of the env files (`.env`, `.env.local`, etc) by setting the `ENV_DIR` directory. The value should be to a folder containing the env files. This value must be specified in the actual environment and *not* in an `.env` file as it is read and evaluated before the env files are read.
+
+```
+ENV_DIR=/var/lib/davis
+```
+
 ### Specific environment variables for IMAP and LDAP authentication methods
 
 In case you use the `IMAP` auth type, you must specify the auth url (_the "mailbox" url_) in `IMAP_AUTH_URL`. See https://www.php.net/manual/en/function.imap-open.php for more details.

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,10 @@
 #!/usr/bin/env php
 <?php
 
+if (getenv('ENV_DIR') !== false && getenv('ENV_DIR') !== '' ) {
+    $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = getenv('ENV_DIR').'/.env';
+}
+
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -28,7 +32,8 @@ if ($input->hasParameterOption('--no-debug', true)) {
     putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+$env_dir = getenv('ENV_DIR') != false ? getenv('ENV_DIR') : dirname(__DIR__);
+(new Dotenv())->bootEnv($env_dir.'/.env');
 
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,9 @@
 <?php
 
+if (getenv('ENV_DIR') !== false && getenv('ENV_DIR') !== '' ) {
+    $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = getenv('ENV_DIR').'/.env';
+}
+
 use App\Kernel;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
@@ -7,7 +11,10 @@ use Symfony\Component\HttpFoundation\Request;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+$env_dir = getenv('ENV_DIR') != false ? getenv('ENV_DIR') : dirname(__DIR__);
+(new Dotenv())->bootEnv($env_dir.'/.env');
+
 
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);


### PR DESCRIPTION
This commit introduces the environment variable `ENV_DIR`.

When provided, davis will load env files (`.env`, `.env.local`, etc.) from this folder instead of loading them from the default location (which is the folder containing `composer.json`)

As discussed in #154.