### PR TITLE
Bugfixes and secure random password generator

### DIFF
--- a/src/Plugins/DavisIMipPlugin.php
+++ b/src/Plugins/DavisIMipPlugin.php
@@ -75,6 +75,15 @@ final class DavisIMipPlugin extends SabreBaseIMipPlugin
         $senderEmail = substr($itip->sender, 7);
         $recipientEmail = substr($itip->recipient, 7);
 
+        if ($itip->senderName) {
+            $senderName = $itip->senderName.' <'.$senderEmail.'>';
+        } else {
+            $senderName = $senderEmail;
+        }
+        if ($itip->recipientName && $itip->recipientName != $recipientEmail) {
+            $recipientName = $itip->recipientName.' <'.$recipientEmail.'>';
+        }
+
         $subject = 'CalDAV message';
         switch (strtoupper($itip->method)) {
             case 'REPLY':


### PR DESCRIPTION
Fix null error with "IMAP Auto Create User" setting and added secure password generator, added check for $senderName so that at least sender's email is shown in subject and "From" display name when $senderName is null