### PR TITLE
LDAP: Allow TLS certificate checking policy to be configured

### DIFF
--- a/.env
+++ b/.env
@@ -59,6 +59,10 @@ LDAP_AUTH_URL="ldap://127.0.0.1"
 LDAP_DN_PATTERN="mail=%u"
 LDAP_MAIL_ATTRIBUTE="mail"
 LDAP_AUTH_USER_AUTOCREATE=false
+# See https://www.php.net/manual/en/ldap.constants.php#constant.ldap-opt-x-tls-require-cert
+# Allowed values are: never, hard, demand, allow or try.
+# "try" is the default if left unspecified
+LDAP_CERTIFICATE_CHECKING_STRATEGY="try"
 
 # Do we enable caldav and carddav ?
 CALDAV_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ LDAP_AUTH_URL="ldap://127.0.0.1"
 LDAP_DN_PATTERN="mail=%u"
 LDAP_MAIL_ATTRIBUTE="mail"
 LDAP_AUTH_USER_AUTOCREATE=true # false by default
+LDAP_CERTIFICATE_CHECKING_STRATEGY="try" # try by default.
 ```
 
 > Ex: for [Zimbra LDAP](https://zimbra.github.io/adminguide/latest/#zimbra_ldap_service), you might want to use the `zimbraMailDeliveryAddress` attribute to retrieve the principal user email:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,6 +35,7 @@ services:
             $LDAPDnPattern: "%env(LDAP_DN_PATTERN)%"
             $LDAPMailAttribute: "%env(LDAP_MAIL_ATTRIBUTE)%"
             $autoCreate: "%env(bool:LDAP_AUTH_USER_AUTOCREATE)%"
+            $LDAPCertificateCheckingStrategy: "%env(LDAP_CERTIFICATE_CHECKING_STRATEGY)%"
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class


### PR DESCRIPTION
In case of a local LDAP server, certificates do not always match the address.
In this case, we cannot connect to the LDAP server.

This PR allows one to configure a policy for certificate checking.

PHP is not my forte, please do not hesitate if anything is not idiomatic nor good :)