### PR TITLE
[Feature] Add calendar public flag option

### DIFF
--- a/.env
+++ b/.env
@@ -69,6 +69,9 @@ CALDAV_ENABLED=true
 CARDDAV_ENABLED=true
 WEBDAV_ENABLED=false
 
+# Can calendar be public available ?
+PUBLIC_CALENDAR_ENABLED=false
+
 # What mail is used as the sender for invites ?
 INVITE_FROM_ADDRESS=no-reply@example.org
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@ parameters:
     default_database_driver: "mysql"
     default_admin_auth_bypass: "false"
     timezone: '%env(APP_TIMEZONE)%'
+    public_calendar_enabled: '%env(bool:PUBLIC_CALENDAR_ENABLED)%'
 
 services:
     # default configuration for services in *this* file

--- a/src/Controller/Admin/CalendarController.php
+++ b/src/Controller/Admin/CalendarController.php
@@ -83,6 +83,7 @@ class CalendarController extends AbstractController
         $form = $this->createForm(CalendarInstanceType::class, $calendarInstance, [
             'new' => !$id,
             'shared' => $calendarInstance->isShared(),
+            'public_calendar_enabled' => $this->getParameter('public_calendar_enabled')
         ]);
 
         $components = explode(',', $calendarInstance->getCalendar()->getComponents());

--- a/src/Form/CalendarInstanceType.php
+++ b/src/Form/CalendarInstanceType.php
@@ -27,14 +27,21 @@ class CalendarInstanceType extends AbstractType
                 'help' => 'form.uri.help.caldav',
                 'required' => true,
             ])
-            ->add('public', ChoiceType::class, [
-                'label' => 'form.public',
-                'mapped' => false,
-                'disabled' => $options['shared'],
-                'help' => 'form.public.help.caldav',
-                'required' => true,
-                'choices' => ['yes' => true, 'no' => false],
-            ])
+            ->add(
+                'public',
+                $options['public_calendar_enabled'] ? ChoiceType::class : HiddenType::class,
+                $options['public_calendar_enabled'] ?  [
+                    'label' => 'form.public',
+                    'mapped' => false,
+                    'disabled' => $options['shared'],
+                    'help' => 'form.public.help.caldav',
+                    'required' => true,
+                    'choices' => ['yes' => true, 'no' => false],
+                ] : [
+                    'required' => true,
+                    'mapped' => false,
+                ]
+            )
             ->add('displayName', TextType::class, [
                 'label' => 'form.displayName',
                 'help' => 'form.name.help.caldav',


### PR DESCRIPTION
Add a .env flag `PUBLIC_CALENDAR_ENABLED` which will show or hide the _public selection_ for calendar. Related to PR https://github.com/tchapi/davis/pull/105.