### PR TITLE
[Chore] Fix .env overriding

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,8 +1,12 @@
 #!/usr/bin/env php
 <?php
 
-if (getenv('ENV_DIR') !== false && getenv('ENV_DIR') !== '' ) {
-    $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = getenv('ENV_DIR').'/.env';
+$overridenEnvDir = getenv('ENV_DIR') ?: null;
+
+if ($overridenEnvDir) {
+    // Tell the Runtime not to touch dotenv so we can load our own file.
+    // This is needed if the ENV_DIR is outside of the project directory
+    $_SERVER['APP_RUNTIME_OPTIONS']['disable_dotenv'] = true;
 }
 
 use App\Kernel;
@@ -19,11 +23,12 @@ if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
+if ($overridenEnvDir) {
+    // Load our own now, after the runtime has booted
+    (new Dotenv())->bootEnv($overridenEnvDir.'/.env');
+}
+
 return function (array $context) {
-
-    $env_dir = getenv('ENV_DIR') != false ? getenv('ENV_DIR') : dirname(__DIR__);
-    (new Dotenv())->bootEnv($env_dir.'/.env');
-
     $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 
     return new Application($kernel);

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,11 @@
 <?php
 
-if (false !== getenv('ENV_DIR') && '' !== getenv('ENV_DIR')) {
-    $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = getenv('ENV_DIR').'/.env';
+$overridenEnvDir = getenv('ENV_DIR') ?: null;
+
+if ($overridenEnvDir) {
+    // Tell the Runtime not to touch dotenv so we can load our own file.
+    // This is needed if the ENV_DIR is outside of the project directory
+    $_SERVER['APP_RUNTIME_OPTIONS']['disable_dotenv'] = true;
 }
 
 use App\Kernel;
@@ -9,9 +13,11 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-return function (array $context) {
-    $env_dir = false != getenv('ENV_DIR') ? getenv('ENV_DIR') : dirname(__DIR__);
-    (new Dotenv())->bootEnv($env_dir.'/.env');
+if ($overridenEnvDir) {
+    // Load our own now, after the runtime has booted
+    (new Dotenv())->bootEnv($overridenEnvDir.'/.env');
+}
 
+return function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };


### PR DESCRIPTION
Allow to override the dotenv path correctly — follow up of https://github.com/tchapi/davis/commit/cca8ed3a49914c81b2f2adcc2ffd3db8b93071f1