### PR TITLE
Move docker env vars to .env

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,32 +1,54 @@
+# General settings
+APP_ENV=prod # or dev
+
+CALDAV_ENABLED=true
+CARDDAV_ENABLED=true
+WEBDAV_ENABLED=false
+PUBLIC_CALENDARS_ENABLED=true
+
+APP_TIMEZONE=Europe/Paris
+
+LOG_FILE_PATH="%kernel.logs_dir%/%kernel.environment%.log"
+
 # For the MariaDB container mainly
 DB_ROOT_PASSWORD=notSoSecure
-
-TIMEZONE=Europe/Paris
 
 # The Davis database, user and password
 DB_DATABASE=davis
 DB_USER=davis_user
 DB_PASSWORD=davis_password
 
-# For the Davis app
+# For the Davis admin interface
 ADMIN_LOGIN=admin
 ADMIN_PASSWORD=admin
+ADMIN_AUTH_BYPASS=false
 
+# DAV auth settings
+AUTH_METHOD=Basic   # Basic or IMAP or LDAP
+
+# Basic HTTP auth settings
 AUTH_REALM=SabreDAV
-AUTH_METHOD=Basic
 
-CALDAV_ENABLED=true
-CARDDAV_ENABLED=true
-WEBDAV_ENABLED=false
+# IMAP auth settings
+IMAP_AUTH_URL={imap.gmail.com:993/imap/ssl/novalidate-cert}
+IMAP_AUTH_USER_AUTOCREATE=false
 
-WEBDAV_TMP_DIR='/tmp'
-WEBDAV_PUBLIC_DIR='/webdav'
+# LDAP auth settings
+LDAP_AUTH_URL=ldap://127.0.0.1:3890
+LDAP_DN_PATTERN=uid=%u,ou=users,dc=domain,dc=com
+LDAP_MAIL_ATTRIBUTE=mail
+LDAP_AUTH_USER_AUTOCREATE=false
+LDAP_CERTIFICATE_CHECKING_STRATEGY=try # never, hard, demand, try, or allow
+
+# WebDAV settings
+WEBDAV_TMP_DIR=/tmp
+WEBDAV_PUBLIC_DIR=/webdav
 WEBDAV_HOMES_DIR=
 
+# Mail settings
 INVITE_FROM_ADDRESS=no-reply@example.org
 MAIL_HOST=smtp.myprovider.com
 MAIL_PORT=587
 MAIL_USERNAME=userdav
 MAIL_PASSWORD=test
 
-LOG_FILE_PATH="%kernel.logs_dir%/%kernel.environment%.log"

--- a/docker/docker-compose-postgresql.yml
+++ b/docker/docker-compose-postgresql.yml
@@ -35,23 +35,11 @@ services:
     # If you want to use a prebuilt image from Github
     # image: ghcr.io/tchapi/davis:edge
     container_name: davis
+    env_file: .env
     environment:
-      - APP_ENV=prod
       - DATABASE_DRIVER=postgresql
       - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@postgresql:5432/${DB_DATABASE}?serverVersion=15&charset=UTF-8
       - MAILER_DSN=smtp://${MAIL_USERNAME}:${MAIL_PASSWORD}@${MAIL_HOST}:${MAIL_PORT}
-      - ADMIN_LOGIN=${ADMIN_LOGIN}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - AUTH_REALM=${AUTH_REALM}
-      - AUTH_METHOD=${AUTH_METHOD}
-      - CALDAV_ENABLED=${CALDAV_ENABLED}
-      - CARDDAV_ENABLED=${CARDDAV_ENABLED}
-      - WEBDAV_ENABLED=${WEBDAV_ENABLED}
-      - WEBDAV_TMP_DIR=${WEBDAV_TMP_DIR}
-      - WEBDAV_PUBLIC_DIR=${WEBDAV_PUBLIC_DIR}
-      - WEBDAV_HOMES_DIR=${WEBDAV_HOMES_DIR}
-      - INVITE_FROM_ADDRESS=${INVITE_FROM_ADDRESS}
-      - APP_TIMEZONE=${TIMEZONE}
     depends_on:
       - postgresql
     volumes:

--- a/docker/docker-compose-sqlite.yml
+++ b/docker/docker-compose-sqlite.yml
@@ -25,23 +25,11 @@ services:
     # If you want to use a prebuilt image from Github
     # image: ghcr.io/tchapi/davis:edge
     container_name: davis
+    env_file: .env
     environment:
-      - APP_ENV=prod
       - DATABASE_DRIVER=sqlite
       - DATABASE_URL=sqlite:////data/davis-database.db # ⚠️ 4 slashes for an absolute path ⚠️ + no quotes (so Symfony can resolve it)
       - MAILER_DSN=smtp://${MAIL_USERNAME}:${MAIL_PASSWORD}@${MAIL_HOST}:${MAIL_PORT}
-      - ADMIN_LOGIN=${ADMIN_LOGIN}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - AUTH_REALM=${AUTH_REALM}
-      - AUTH_METHOD=${AUTH_METHOD}
-      - CALDAV_ENABLED=${CALDAV_ENABLED}
-      - CARDDAV_ENABLED=${CARDDAV_ENABLED}
-      - WEBDAV_ENABLED=${WEBDAV_ENABLED}
-      - WEBDAV_TMP_DIR=${WEBDAV_TMP_DIR}
-      - WEBDAV_PUBLIC_DIR=${WEBDAV_PUBLIC_DIR}
-      - WEBDAV_HOMES_DIR=${WEBDAV_HOMES_DIR}
-      - INVITE_FROM_ADDRESS=${INVITE_FROM_ADDRESS}
-      - APP_TIMEZONE=${TIMEZONE}
     volumes:
       - davis_www:/var/www/davis
       - davis_data:/data

--- a/docker/docker-compose-standalone.yml
+++ b/docker/docker-compose-standalone.yml
@@ -22,23 +22,11 @@ services:
     # If you want to use a prebuilt image from Github
     # image: ghcr.io/tchapi/davis-standalone:edge
     container_name: davis-standalone
+    env_file: .env
     environment:
-      - APP_ENV=prod
       - DATABASE_DRIVER=mysql
       - DATABASE_URL=mysql://${DB_USER}:${DB_PASSWORD}@mysql:3306/${DB_DATABASE}?serverVersion=mariadb-10.6.10&charset=utf8mb4
       - MAILER_DSN=smtp://${MAIL_USERNAME}:${MAIL_PASSWORD}@${MAIL_HOST}:${MAIL_PORT}
-      - ADMIN_LOGIN=${ADMIN_LOGIN}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - AUTH_REALM=${AUTH_REALM}
-      - AUTH_METHOD=${AUTH_METHOD}
-      - CALDAV_ENABLED=${CALDAV_ENABLED}
-      - CARDDAV_ENABLED=${CARDDAV_ENABLED}
-      - WEBDAV_ENABLED=${WEBDAV_ENABLED}
-      - WEBDAV_TMP_DIR=${WEBDAV_TMP_DIR}
-      - WEBDAV_PUBLIC_DIR=${WEBDAV_PUBLIC_DIR}
-      - WEBDAV_HOMES_DIR=${WEBDAV_HOMES_DIR}
-      - INVITE_FROM_ADDRESS=${INVITE_FROM_ADDRESS}
-      - APP_TIMEZONE=${TIMEZONE}
     depends_on:
       - mysql
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,23 +38,11 @@ services:
     # If you want to use a prebuilt image from Github
     # image: ghcr.io/tchapi/davis:edge
     container_name: davis
+    env_file: .env
     environment:
-      - APP_ENV=prod
       - DATABASE_DRIVER=mysql
       - DATABASE_URL=mysql://${DB_USER}:${DB_PASSWORD}@mysql:3306/${DB_DATABASE}?serverVersion=mariadb-10.6.10&charset=utf8mb4
       - MAILER_DSN=smtp://${MAIL_USERNAME}:${MAIL_PASSWORD}@${MAIL_HOST}:${MAIL_PORT}
-      - ADMIN_LOGIN=${ADMIN_LOGIN}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - AUTH_REALM=${AUTH_REALM}
-      - AUTH_METHOD=${AUTH_METHOD}
-      - CALDAV_ENABLED=${CALDAV_ENABLED}
-      - CARDDAV_ENABLED=${CARDDAV_ENABLED}
-      - WEBDAV_ENABLED=${WEBDAV_ENABLED}
-      - WEBDAV_TMP_DIR=${WEBDAV_TMP_DIR}
-      - WEBDAV_PUBLIC_DIR=${WEBDAV_PUBLIC_DIR}
-      - WEBDAV_HOMES_DIR=${WEBDAV_HOMES_DIR}
-      - INVITE_FROM_ADDRESS=${INVITE_FROM_ADDRESS}
-      - APP_TIMEZONE=${TIMEZONE}
     depends_on:
       - mysql
     volumes:


### PR DESCRIPTION
In the current version of the docker-compose file, configuration options are specified in `.env` and then passed to the container using `ENV_VAR=${ENV_VAR}` under the `environment` section of the docker-compose file. This PR instead passes `.env` to the container directly, so any changes/additions made to `.env` are applied to the container without needing to add a corresponding entry in `environment`. 

The motivation for this change is that in configuring LDAP on my installation of Davis, I was adding the LDAP env vars to `.env` but forgetting to pass them in the compose file. All the examples in the README use env-file syntax, so I just copied those over to my `.env` file without thinking. It took a few hours debugging my LDAP provider before realizing that Davis was never seeing any of my changes in the first place! 

Setting aside my personal oversights, I prefer this method because it reduces redundant code (i.e. adding an entry in `.env` and a corresponding entry in `environment` per variable) which means less maintenance when additional configuration variables are added. It also reduces duplicated code across the four different compose files. 

This PR also propagates https://github.com/tchapi/davis/commit/c29dc78a921110c77cb3d3f285e13e5c053cae3e to the `.env` file in the docker configuration directory. 