### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Dependencies
 1. Retrieve the dependencies:
 
     ```
-    composer install
+    composer install --no-dev
     ```
+
+    Remove `--no-dev` if you plan to install Davis locally for e.g. development purposes.
 
 2. At least put the correct credentials to your database (driver and url) in your `.env.local` file so you can easily create the necessary tables.
 
@@ -92,6 +94,10 @@ Create your own `.env.local` file to change the necessary variables, if you plan
 > [!NOTE]
 >
 > If your installation is behind a web server like Apache or Nginx, you can setup the env vars directly in your Apache or Nginx configuration (see below). Skip this part in this case.
+
+> [!CAUTION]
+>
+> In a production environnement, the `APP_ENV` variable MUST be set to `prod`.
 
 **a. The database driver and url** (_you should already have it configured since you created the database previously_)
     


### PR DESCRIPTION
Hey,

Here's two little improvements regarding the README:

  - In the "Installation" section, added `--no-dev` to `composer install`. Dev dependencies must NEVER be installed on a production environment, but mention it must be removed (for e.g. development purposes)
  - Added an admonition regarding `APP_ENV=prod` which MUST be set in a production environment to prevent leaking sensitive data

Thank you for Davis, much better than Baïkal!