### PR TITLE
minor: null check

### DIFF
--- a/src/Plugins/PublicAwareDAVACLPlugin.php
+++ b/src/Plugins/PublicAwareDAVACLPlugin.php
@@ -54,17 +54,19 @@ class PublicAwareDAVACLPlugin extends \Sabre\DAVACL\Plugin
                 // a new class just to access it, so we use a closure.
                 $calendarInfo = (fn () => $this->calendarInfo)->call($node);
                 // [0] is the calendarId, [1] is the calendarInstanceId
-                $calendarInstanceId = $calendarInfo['id'][1];
+                if (isset($calendarInfo['id']) && is_array($calendarInfo['id']) && isset($calendarInfo['id'][1])) {
+                    $calendarInstanceId = $calendarInfo['id'][1];
 
-                $calendar = $this->em->getRepository(CalendarInstance::class)->findOneById($calendarInstanceId);
+                    $calendar = $this->em->getRepository(CalendarInstance::class)->findOneById($calendarInstanceId);
 
-                if ($calendar && $calendar->isPublic()) {
-                    // Add unauthenticated read access on the object itself
-                    $acl[] = [
-                        'principal' => '{DAV:}unauthenticated',
-                        'privilege' => '{DAV:}read',
-                        'protected' => false,
-                    ];
+                    if ($calendar && $calendar->isPublic()) {
+                        // Add unauthenticated read access on the object itself
+                        $acl[] = [
+                            'principal' => '{DAV:}unauthenticated',
+                            'privilege' => '{DAV:}read',
+                            'protected' => false,
+                        ];
+                    }
                 }
             }
         }


### PR DESCRIPTION
I had auto updates on the container on and the `edge` tag set - not my wisest decision - and I assume something got itself into a bad state. 

In either case, my Mac refused to sync to Davis with

```
php.ERROR: Warning: Undefined array key "id" {"exception":"[object] (ErrorException(code: 0): Warning: Undefined array key \"id\" at /var/www/davis/src/Plugins/PublicAwareDAVACLPlugin.php:57)"} []
php.ERROR: Warning: Trying to access array offset on null {"exception":"[object] (ErrorException(code: 0): Warning: Trying to access array offset on null at /var/www/davis/src/Plugins/PublicAwareDAVACLPlugin.php:57)"} []
```

So this adds a null check to `PublicAwareDAVACLPlugin`

I tested this via
```bash
docker buildx build \
  --platform linux/amd64 \
  -f docker/Dockerfile-standalone \
  -t ${DOCKER_REGISTRY}/davis-standalone:fixed \
   --build-arg fpm_user=82:82 \
  --push \
  .
```

I run mySQL on a remote instance, so my compose file is just `davis-standalone`.