### PR TITLE
Provide mixed authentication using Basic and LDAP modules

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -45,6 +45,15 @@ services:
             $LDAPCertificateCheckingStrategy: "%env(LDAP_CERTIFICATE_CHECKING_STRATEGY)%"
             $autoCreate: "%env(bool:LDAP_AUTH_USER_AUTOCREATE)%"
 
+    App\Services\LDAPFallbackAuth:
+        arguments:
+            $LDAPAuthUrl: "%env(LDAP_AUTH_URL)%"
+            $LDAPDnPattern: "%env(LDAP_DN_PATTERN)%"
+            $LDAPMailAttribute: "%env(LDAP_MAIL_ATTRIBUTE)%"
+            $LDAPCertificateCheckingStrategy: "%env(LDAP_CERTIFICATE_CHECKING_STRATEGY)%"
+            $autoCreate: "%env(bool:LDAP_AUTH_USER_AUTOCREATE)%"
+            $whichFirst: "%env(AUTH_WHICH_PROVIDER_FIRST)%"
+
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class
     App\Controller\:

--- a/src/Controller/DAVController.php
+++ b/src/Controller/DAVController.php
@@ -11,6 +11,7 @@ use App\Services\BasicAuth;
 use App\Services\BirthdayService;
 use App\Services\IMAPAuth;
 use App\Services\LDAPAuth;
+use App\Services\LDAPFallbackAuth;
 use Doctrine\ORM\EntityManagerInterface;
 use PDO;
 use Psr\Log\LoggerInterface;
@@ -27,6 +28,7 @@ class DAVController extends AbstractController
     public const AUTH_BASIC = 'Basic';
     public const AUTH_IMAP = 'IMAP';
     public const AUTH_LDAP = 'LDAP';
+    public const AUTH_LDAP_AND_BASIC = 'BasicAndLDAP';
 
     /**
      * Is CalDAV enabled?
@@ -136,6 +138,13 @@ class DAVController extends AbstractController
     protected $LDAPAuthBackend;
 
     /**
+     * LDAP with Fallback Auth Backend class.
+     *
+     * @var LDAPFallbackAuth
+     */
+    protected $LDAPFallbackAuthBackend;
+
+    /**
      * Logger for exceptions.
      *
      * @var Psr\Log\LoggerInterface;
@@ -149,7 +158,7 @@ class DAVController extends AbstractController
      */
     protected $server;
 
-    public function __construct(MailerInterface $mailer, BasicAuth $basicAuthBackend, IMAPAuth $IMAPAuthBackend, LDAPAuth $LDAPAuthBackend, UrlGeneratorInterface $router, EntityManagerInterface $entityManager, LoggerInterface $logger, BirthdayService $birthdayService, string $publicDir, bool $calDAVEnabled = true, bool $cardDAVEnabled = true, bool $webDAVEnabled = false, bool $publicCalendarsEnabled = true, ?string $inviteAddress = null, ?string $authMethod = null, ?string $authRealm = null, ?string $webdavPublicDir = null, ?string $webdavHomesDir = null, ?string $webdavTmpDir = null)
+    public function __construct(MailerInterface $mailer, BasicAuth $basicAuthBackend, IMAPAuth $IMAPAuthBackend, LDAPAuth $LDAPAuthBackend, LDAPFallbackAuth $LDAPFallbackAuthBackend, UrlGeneratorInterface $router, EntityManagerInterface $entityManager, LoggerInterface $logger, BirthdayService $birthdayService, string $publicDir, bool $calDAVEnabled = true, bool $cardDAVEnabled = true, bool $webDAVEnabled = false, bool $publicCalendarsEnabled = true, ?string $inviteAddress = null, ?string $authMethod = null, ?string $authRealm = null, ?string $webdavPublicDir = null, ?string $webdavHomesDir = null, ?string $webdavTmpDir = null)
     {
         $this->publicDir = $publicDir;
 
@@ -172,6 +181,7 @@ class DAVController extends AbstractController
         $this->basicAuthBackend = $basicAuthBackend;
         $this->IMAPAuthBackend = $IMAPAuthBackend;
         $this->LDAPAuthBackend = $LDAPAuthBackend;
+        $this->LDAPFallbackAuthBackend = $LDAPFallbackAuthBackend;
 
         $this->initServer($authMethod, $authRealm);
         $this->initExceptionListener();
@@ -199,6 +209,9 @@ class DAVController extends AbstractController
                 break;
             case self::AUTH_LDAP:
                 $authBackend = $this->LDAPAuthBackend;
+                break;
+            case self::AUTH_LDAP_AND_BASIC:
+                $authBackend = $this->LDAPFallbackAuthBackend;
                 break;
             case self::AUTH_BASIC:
             default:

--- a/src/Services/LDAPFallbackAuth.php
+++ b/src/Services/LDAPFallbackAuth.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use App\Entity\User;
+use App\Services\BasicAuth;
+use App\Services\LDAPAuth;
+use Doctrine\Persistence\ManagerRegistry;
+use Sabre\DAV\Auth\Backend\AbstractBasic;
+
+final class LDAPFallbackAuth extends AbstractBasic
+{
+  
+    public const PROVIDER_BASIC = 'Basic';
+    public const PROVIDER_LDAP = 'LDAP';
+    
+    /**
+     * LDAP authenticator.
+     *
+     * @var App\Services\LDAPAuth
+     */
+    private $LDAPAuth;
+
+    /**
+     * Basic authenticator.
+     *
+     * @var App\Services\BasicAuth
+     */
+    private $BasicAuth;
+
+    /**
+     * Configure which authenticator to check first.
+     * 
+     * Either 'LDAP' or 'Basic'
+     * 
+     * @var string
+     * 
+     */
+    private $whichFirst;
+
+    /**
+     * Creates the backend object.
+     */
+    public function __construct(ManagerRegistry $doctrine, Utils $utils, string $LDAPAuthUrl, string $LDAPDnPattern, ?string $LDAPMailAttribute, bool $autoCreate, ?string $LDAPCertificateCheckingStrategy, ?string $whichFirst)
+    {
+      
+        $this->LDAPAuth = new LDAPAuth($doctrine, $utils,  $LDAPAuthUrl, $LDAPDnPattern, $LDAPMailAttribute ?? 'mail', $autoCreate, $LDAPCertificateCheckingStrategy  ?? 'try' );
+        $this->BasicAuth = new BasicAuth($doctrine, $utils);
+        $this->whichFirst = $whichFirst ?? PROVIDER_BASIC;
+      
+        $this->doctrine = $doctrine;
+        $this->utils = $utils;
+    }
+
+    /**
+     * Validates a username and password by trying to authenticate against LDAP.
+     *
+     * @param string $username
+     * @param string $password
+     */
+    protected function validateUserPass($username, $password): bool
+    {
+        /*
+         * Use the backends.
+         */
+        switch ($this->whichFirst) {
+            case self::PROVIDER_BASIC:
+                if(!$this->BasicAuth->validateUserPass($username, $password)){
+                  return $this->LDAPAuth->validateUserPass($username, $password);
+                }else{
+                  return true;
+                }
+            case self::PROVIDER_LDAP:
+                if(!$this->LDAPAuth->validateUserPass($username, $password)){
+                  return $this->BasicAuth->validateUserPass($username, $password);
+                }else{
+                  return true;
+                }
+        }
+        return false;
+    }
+}

--- a/src/Services/LDAPFallbackAuth.php
+++ b/src/Services/LDAPFallbackAuth.php
@@ -53,7 +53,7 @@ final class LDAPFallbackAuth extends AbstractBasic
     }
 
     /**
-     * Validates a username and password by trying to authenticate against LDAP.
+     * Validates a username and password by trying to authenticate against LDAP and local database.
      *
      * @param string $username
      * @param string $password


### PR DESCRIPTION
Hi,

thanks again for this great software!

In our setting, we have a combination of LDAP-accounts and local accounts. So I came up with this mixed authenticator that uses both LDAP and Basic authenticators.

Internally, the LDAPFallbackAuth-Backend just uses the existing Basic and LDAP authentication backends which keeps modifications minimal. A new `whichFirst` config option allows to specify which authenticator should be checked first - `Basic` or `LDAP`.

Looking forward to your thoughts!