### PR TITLE
feat: ICS Calendars plugin

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -13,6 +13,8 @@ parameters:
     default_birthday_reminder_offset: "PT9H"
     caldav_enabled: "%env(bool:CALDAV_ENABLED)%"
     carddav_enabled: "%env(bool:CARDDAV_ENABLED)%"
+    icscalendars_enabled: "%env(default:default_icscalendars_enabled:bool:ICSCALENDARS_ENABLED)%"
+    default_icscalendars_enabled: "0"
 
 services:
     # default configuration for services in *this* file
@@ -77,6 +79,10 @@ services:
     App\Services\BirthdayService:
         arguments:
             $birthdayReminderOffset: "%birthday_reminder_offset%"
+
+    App\Services\ICSCalendarsService:
+        arguments:
+            $enabled: "%icscalendars_enabled%"
 
     App\Security\ApiKeyAuthenticator:
         arguments:

--- a/src/Command/SyncICSCalendars.php
+++ b/src/Command/SyncICSCalendars.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\CalendarSubscription;
+use App\Services\ICSCalendarsService;
+use Doctrine\Persistence\ManagerRegistry;
+use Sabre\CalDAV\Backend\PDO as CalendarBackend;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SyncICSCalendars extends Command
+{
+    public function __construct(
+        private ManagerRegistry $doctrine,
+        private ICSCalendarsService $icsService,
+    ) {
+        parent::__construct();
+
+        $em = $doctrine->getManager();
+        $pdo = $em->getConnection()->getNativeConnection();
+        $this->icsService->setBackend(new CalendarBackend($pdo));
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('dav:sync-ics-calendars')
+            ->setDescription('Synchronizes the ICS calendars');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->icsService->isEnabled()) {
+            $output->writeln('ICS calendars are disabled.');
+            $output->writeln('Enable ICS calendars by setting ICSCALENDARS_ENABLED=true.');
+            return self::SUCCESS;
+        }
+
+        $output->writeln('Start ICS calendars sync ...');
+        $p = new ProgressBar($output);
+        $p->start();
+
+        $subscriptions = $this->doctrine->getRepository(CalendarSubscription::class)->findAll();
+
+        foreach ($subscriptions as $subscription) {
+            $p->advance();
+            $this->icsService->sync($subscription);
+        }
+
+        $p->finish();
+        $output->writeln('');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Controller/DAVController.php
+++ b/src/Controller/DAVController.php
@@ -7,12 +7,13 @@ use App\Entity\User;
 use App\Plugins\BirthdayCalendarPlugin;
 use App\Plugins\DavisIMipPlugin;
 use App\Plugins\PublicAwareDAVACLPlugin;
+use App\Plugins\ICSCalendarsPlugin;
 use App\Services\BasicAuth;
 use App\Services\BirthdayService;
+use App\Services\ICSCalendarsService;
 use App\Services\IMAPAuth;
 use App\Services\LDAPAuth;
 use Doctrine\ORM\EntityManagerInterface;
-use PDO;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -108,6 +109,11 @@ class DAVController extends AbstractController
     protected $birthdayService;
 
     /**
+     * @var ICSCalendarsService
+     */
+    protected $icsCalendarsService;
+
+    /**
      * Base URI of the server.
      *
      * @var string
@@ -149,7 +155,7 @@ class DAVController extends AbstractController
      */
     protected $server;
 
-    public function __construct(MailerInterface $mailer, BasicAuth $basicAuthBackend, IMAPAuth $IMAPAuthBackend, LDAPAuth $LDAPAuthBackend, UrlGeneratorInterface $router, EntityManagerInterface $entityManager, LoggerInterface $logger, BirthdayService $birthdayService, string $publicDir, bool $calDAVEnabled = true, bool $cardDAVEnabled = true, bool $webDAVEnabled = false, bool $publicCalendarsEnabled = true, ?string $inviteAddress = null, ?string $authMethod = null, ?string $authRealm = null, ?string $webdavPublicDir = null, ?string $webdavHomesDir = null, ?string $webdavTmpDir = null)
+    public function __construct(MailerInterface $mailer, BasicAuth $basicAuthBackend, IMAPAuth $IMAPAuthBackend, LDAPAuth $LDAPAuthBackend, UrlGeneratorInterface $router, EntityManagerInterface $entityManager, LoggerInterface $logger, BirthdayService $birthdayService, ICSCalendarsService $icsCalendarsService, string $publicDir, bool $calDAVEnabled = true, bool $cardDAVEnabled = true, bool $webDAVEnabled = false, bool $publicCalendarsEnabled = true, ?string $inviteAddress = null, ?string $authMethod = null, ?string $authRealm = null, ?string $webdavPublicDir = null, ?string $webdavHomesDir = null, ?string $webdavTmpDir = null)
     {
         $this->publicDir = $publicDir;
 
@@ -167,6 +173,7 @@ class DAVController extends AbstractController
         $this->logger = $logger;
         $this->mailer = $mailer;
         $this->birthdayService = $birthdayService;
+        $this->icsCalendarsService = $icsCalendarsService;
         $this->baseUri = $router->generate('dav', ['path' => '']);
 
         $this->basicAuthBackend = $basicAuthBackend;
@@ -273,6 +280,7 @@ class DAVController extends AbstractController
             if ($this->inviteAddress) {
                 $this->server->addPlugin(new DavisIMipPlugin($this->mailer, $this->inviteAddress, $this->publicDir));
             }
+            $this->server->addPlugin(new ICSCalendarsPlugin($this->icsCalendarsService, $calendarBackend));
         }
 
         // CardDAV plugins

--- a/src/Entity/CalendarInstance.php
+++ b/src/Entity/CalendarInstance.php
@@ -140,7 +140,7 @@ class CalendarInstance
 
     public function isAutomaticallyGenerated(): bool
     {
-        return in_array($this->uri, [Constants::BIRTHDAY_CALENDAR_URI]);
+        return $this->uri === Constants::BIRTHDAY_CALENDAR_URI || str_ends_with($this->uri, '.ics');
     }
 
     public function getDisplayName(): ?string

--- a/src/Plugins/ICSCalendarsPlugin.php
+++ b/src/Plugins/ICSCalendarsPlugin.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins;
+
+use App\Services\ICSCalendarsService;
+use Sabre\CalDAV\Backend\PDO as CalendarBackend;
+use Sabre\CalDAV\Subscriptions\ISubscription;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+
+class ICSCalendarsPlugin extends ServerPlugin
+{
+    private ICSCalendarsService $icsService;
+    private Server $server;
+
+    public function __construct(ICSCalendarsService $icsService, CalendarBackend $calendarBackend)
+    {
+        $this->icsService = $icsService;
+        $this->icsService->setBackend($calendarBackend);
+    }
+
+    public function initialize(Server $server)
+    {
+        $this->server = $server;
+
+        // Hook into creation
+        $server->on('afterBind', [$this, 'afterSubscriptionCreate']);
+
+        // Hook into deletion
+        // Note: The node no longer exists after unbind so we hook in before
+        $server->on('beforeUnbind', [$this, 'beforeSubscriptionDelete']);
+    }
+
+    public function afterSubscriptionCreate(string $path): void
+    {
+        $node = $this->server->tree->getNodeForPath($path);
+        if (!$node instanceof ISubscription) {
+            return;
+        }
+
+        $this->icsService->onSubscriptionCreate($node->getProperties(['id'])['id']);
+    }
+
+    public function beforeSubscriptionDelete(string $path): void
+    {
+        $node = $this->server->tree->getNodeForPath($path);
+        if (!$node instanceof ISubscription) {
+            return;
+        }
+
+        $this->icsService->onSubscriptionDelete($node->getProperties(['id'])['id']);
+    }
+
+    public function getPluginInfo()
+    {
+        return [
+            'name' => $this->getPluginName(),
+            'description' => 'Creates calendars for Subscriptions.',
+            'link' => 'https://github.com/tchapi/davis',
+        ];
+    }
+}

--- a/src/Services/ICSCalendarsService.php
+++ b/src/Services/ICSCalendarsService.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Entity\Calendar;
+use App\Entity\CalendarInstance;
+use App\Entity\CalendarSubscription;
+use Doctrine\Persistence\ManagerRegistry;
+use Sabre\CalDAV\Backend\PDO as CalendarBackend;
+use Sabre\DAV\Sharing\Plugin as SharingPlugin;
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ICSCalendarsService
+{
+    private CalendarBackend $calendarBackend;
+
+    public function __construct(
+        private ManagerRegistry $doctrine,
+        private HttpClientInterface $client,
+        private bool $enabled,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setBackend(CalendarBackend $calendarBackend): void
+    {
+        $this->calendarBackend = $calendarBackend;
+    }
+
+    public function sync(CalendarSubscription $subscription): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        $vcalendar = $this->retrieve($subscription->getSource());
+        if ($vcalendar === null) {
+            return;
+        }
+
+        $principalUri = $subscription->getPrincipalUri();
+        $calendarUri = sha1($subscription->getSource()).'.ics';
+        $calendarInstance = $this->doctrine->getRepository(CalendarInstance::class)->findOneBy(['principalUri' => $principalUri, 'uri' => $calendarUri]);
+
+        if ($calendarInstance === null) {
+            $em = $this->doctrine->getManager();
+
+            $calendarInstance = $this->doctrine->getRepository(CalendarInstance::class)->findOneBy(['uri' => $calendarUri]);
+            if ($calendarInstance === null) {
+                $calendarComponents = [Calendar::COMPONENT_EVENTS, Calendar::COMPONENT_NOTES];
+                if ($subscription->getStripTodos() === null) {
+                    $calendarComponents[] = Calendar::COMPONENT_TODOS;
+                }
+
+                $calendar = new Calendar();
+                $calendar->setComponents(implode(',', $calendarComponents));
+                $em->persist($calendar);
+            } else {
+                $calendar = $calendarInstance->getCalendar();
+            }
+
+            $calendarInstance = (new CalendarInstance())
+                ->setPrincipalUri($principalUri)
+                ->setDisplayName($subscription->getDisplayName())
+                ->setDescription('Calendar mirror for subscription '.$subscription->getDisplayName())
+                ->setAccess(SharingPlugin::ACCESS_READ)
+                ->setCalendarOrder($subscription->getCalendarOrder())
+                ->setCalendarColor($subscription->getCalendarColor())
+                ->setCalendar($calendar)
+                ->setShareInviteStatus(SharingPlugin::INVITE_ACCEPTED)
+                ->setUri($calendarUri);
+            $em->persist($calendarInstance);
+            $em->flush();
+        } else {
+            $calendar = $calendarInstance->getCalendar();
+        }
+
+        $existingUris = [];
+        foreach ($calendar->getObjects() as $object) {
+            $existingUris[] = $object->getUri();
+        }
+
+        $elements = ['VEVENT', 'VJOURNAL'];
+        if ($subscription->getStripTodos() === null) {
+            $elements[] = 'VTODO';
+        }
+
+        $seenUris = [];
+        $backendId = [$calendar->getId(), $calendarInstance->getId()];
+        foreach ($elements as $element) {
+            foreach ($vcalendar->select($element) as $event) {
+                $uid = $event->UID->getValue();
+                if ($uid === null) {
+                    continue;
+                }
+
+                // Stable URI derived from UID
+                $objectUri = sha1($uid).'.ics';
+                $seenUris[] = $objectUri;
+
+                if ($subscription->getStripAlarms() !== null) {
+                    $event->remove('VALARM');
+                }
+
+                if ($subscription->getStripAttachments() !== null) {
+                    $event->remove('ATTACH');
+                }
+
+                $eventCalendar = new VCalendar();
+                $eventCalendar->add($event);
+
+                if (in_array($objectUri, $existingUris, true)) {
+                    $this->calendarBackend->updateCalendarObject(
+                        $backendId,
+                        $objectUri,
+                        $eventCalendar->serialize()
+                    );
+                } else {
+                    $this->calendarBackend->createCalendarObject(
+                        $backendId,
+                        $objectUri,
+                        $eventCalendar->serialize()
+                    );
+                }
+            }
+        }
+
+        foreach ($existingUris as $uri) {
+            if (!in_array($uri, $seenUris, true)) {
+                $this->calendarBackend->deleteCalendarObject(
+                    $backendId,
+                    $uri
+                );
+            }
+        }
+    }
+
+    public function onSubscriptionCreate(int $subscriptionId): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        $subscription = $this->doctrine->getRepository(CalendarSubscription::class)->findOneById($subscriptionId);
+        $this->sync($subscription);
+    }
+
+    public function onSubscriptionDelete(int $subscriptionId): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        $subscription = $this->doctrine->getRepository(CalendarSubscription::class)->findOneById($subscriptionId);
+
+        $principalUri = $subscription->getPrincipalUri();
+        $calendarUri = sha1($subscription->getSource()).'.ics';
+        $calendarInstance = $this->doctrine->getRepository(CalendarInstance::class)->findOneBy(['principalUri' => $principalUri, 'uri' => $calendarUri]);
+        if ($calendarInstance === null) {
+            return;
+        }
+
+        $em = $this->doctrine->getManager();
+
+        $em->remove($calendarInstance);
+
+        $calendar = $calendarInstance->getCalendar();
+        $calendar->getInstances()->removeElement($calendarInstance);
+        if ($calendar->getInstances()->isEmpty()) {
+            foreach ($calendar->getObjects() as $object) {
+                $em->remove($object);
+            }
+            foreach ($calendar->getChanges() as $change) {
+                $em->remove($change);
+            }
+
+            $em->remove($calendar);
+        }
+
+        $em->flush();
+    }
+
+    private function retrieve(string $url): ?VCalendar
+    {
+        $response = $this->client->request('GET', $url);
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        try {
+            $vcal = Reader::read($response->getContent());
+            if ($vcal instanceof VCalendar) {
+                return $vcal;
+            }
+        } catch (\Exception $e) { }
+
+        return null;
+    }
+}


### PR DESCRIPTION
I was looking to replace my old calendar setup and decided to switch to Davis but coming from DAViCal there was one thing I was really missing; the external bind functionality it provided. As not all clients can automatically handle advertised webcals, I needed work-arounds or would just not have access to certain calendars on certain devices.  
This plugin is heavily inspired by that functionality to facilitate something similar by utilizing the subscriptions functionality already present in Davis.  

In short, when the plugin is enabled, it will create calendars for each added subscription, re-using any existing data.  
When the subscription is removed, so is the calendar (for the given user only or completely if no other user has it anymore).  

A (re-)sync can be forced with the `dav:sync-ics-calendars` console command.  


Note that there's very few clients that actually allow you to add subscriptions to the server in the first place. While adding a custom command or BIND method like DAViCal had done would also have been possible, the subscriptions can already be created using a normal `MKCALENDAR` operation. As such, I opted not to add anything custom.  
If anything, expanding the webinterface to allow managing subscriptions would likely be the much better way to go.  

In the mean time, to create a subscription you'd use roughly something like:
```
curl -u '<user>:<pass>' \
  -X MKCALENDAR \
  -H 'Content-Type: application/xml; charset=utf-8' \
  --data '<?xml version="1.0"?>
<C:mkcalendar xmlns:D="DAV:"
    xmlns:C="urn:ietf:params:xml:ns:caldav"
    xmlns:CS="http://calendarserver.org/ns/"
    xmlns:I="http://apple.com/ns/ical/">
  <D:set>
    <D:prop>
      <D:displayname>Subscribed Holidays</D:displayname>
      <D:resourcetype>
        <D:collection/>
        <CS:subscribed/>
      </D:resourcetype>
      <CS:source>
        <D:href>https://calendars.icloud.com/holidays/nl_nl.ics</D:href>
      </CS:source>
      <I:calendar-color>#FF9500FF</I:calendar-color>
      <I:calendar-order>0</I:calendar-order>
    </D:prop>
  </D:set>
</C:mkcalendar>' \
  'http://<host>/dav/calendars/<user>/<subscription-uri>/'
```

Removal is simply a DELETE on the same URL:
```
curl -u '<user>:<pass>' \
  -X DELETE \
  'http://<host>/dav/calendars/<user>/<subscription-uri>/'
```

This results in something like:  
<img width="1344" height="730" alt="screenshot_2026-05-29T18:42:50" src="https://github.com/user-attachments/assets/7140d244-1e66-4277-a959-aef4d2b1b1b6" />


Automatic (re-)sync based on a subscription's `refreshrate` and/or a default fallback interval within Davis itself is currently not implemented. Refreshing on a fixed interval can be done by using the `dav:sync-ics-calendars` console command (e.g. scheduling it with cron).  