### PR TITLE
Harden admin mutations and calendar color rendering

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -2,7 +2,7 @@
 framework:
     secret: '%env(APP_SECRET)%'
     handle_all_throwables: true
-    #csrf_protection: true
+    csrf_protection: true
     http_method_override: false
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -21,6 +21,7 @@ security:
             logout:
                 path: app_logout
                 target: dashboard
+                enable_csrf: true
             
 
     access_control:

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -7,19 +7,10 @@ if (shareModal) {
         // Button that triggered the modal
         const button = event.relatedTarget
 
-        // Grab calendar shares url and add url
+        // Grab calendar shares URL and share target.
         let shareesUrl = button.getAttribute('data-sharees-href');
         let targetUrl = button.getAttribute('data-href');
-
-        // When adding the sharee, catch the click to add the query parameter
-        const addShareeButton = document.getElementById('shareModal-addSharee');
-        addShareeButton.addEventListener("click", function(e) {
-            const writeAccess = document.getElementById('shareModal-writeAccess').checked ? 'true' : 'false';
-            const principalId = document.getElementById('shareModal-member').value;
-
-            e.preventDefault()
-            window.location = targetUrl + "?principalId=" + principalId + "&write=" + writeAccess
-        });
+        document.getElementById('shareModal-addForm').setAttribute('action', targetUrl)
 
         const noneElement = document.getElementById('shareModal-none')
 
@@ -53,8 +44,8 @@ if (shareModal) {
                         badge[0].classList.add('bg-success')
                         badge[0].classList.remove('bg-info')
                     }
-                    let revokeButton = clone.querySelectorAll("a.revoke");
-                    revokeButton[0].href = element.revokeUrl;
+                    let revokeForm = clone.querySelectorAll("form.revoke");
+                    revokeForm[0].setAttribute('action', element.revokeUrl);
 
                     shares.appendChild(clone);
                 });
@@ -71,36 +62,15 @@ deleteModals.forEach(element => {
         // Button that triggered the modal
         const button = event.relatedTarget
 
-        // Grab real target url for deletion
+        // Grab the target URL for deletion.
         let targetUrl = button.getAttribute('data-href');
         let modalFlavour = button.getAttribute('data-flavour');
 
-        // Put it into the modal's OK button
-        const deleteCTA = document.getElementById(`deleteModal-${modalFlavour}-cta`);
-        console.log("setting href to " + targetUrl)
-        deleteCTA.setAttribute('href', targetUrl);
+        // Put it into the modal's confirmation form.
+        const deleteForm = document.getElementById(`deleteModal-${modalFlavour}-form`);
+        deleteForm.setAttribute('action', targetUrl);
     })
 })
-
-
-
-// Global account delegation modal
-const addDelegateModal = document.getElementById('addDelegateModal')
-if (addDelegateModal) {
-    addDelegateModal.addEventListener('show.bs.modal', event => {
-        // When adding the sharee, catch the click to add the query parameter
-        const addDelegateButton = document.getElementById('addDelegateModal-cta');
-        addDelegateButton.addEventListener("click", function(e) {
-            const targetUrl = addDelegateButton.getAttribute('data-href');
-            const writeAccess = document.getElementById('addDelegateModal-writeAccess').checked ? 'true' : 'false';
-            const principalId = document.getElementById('addDelegateModal-member').value;
-
-            e.preventDefault()
-            window.location = targetUrl + "?principalId=" + principalId + "&write=" + writeAccess
-        });
-
-    })
-}
 
 // Color swatch: update it live (not working in IE ¯\_(ツ)_/¯ but it's just a nice to have)
 const colorPicker = document.getElementById('calendar_instance_calendarColor');

--- a/src/Controller/Admin/AddressBookController.php
+++ b/src/Controller/Admin/AddressBookController.php
@@ -12,12 +12,13 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/addressbooks', name: 'addressbook_')]
 class AddressBookController extends AbstractController
 {
-    #[Route('/{userId}', name: 'index')]
+    #[Route('/{userId}', name: 'index', methods: ['GET'])]
     public function addressBooks(ManagerRegistry $doctrine, int $userId): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -38,8 +39,8 @@ class AddressBookController extends AbstractController
         ]);
     }
 
-    #[Route('/{userId}/new', name: 'create')]
-    #[Route('/{userId}/edit/{id}', name: 'edit', requirements: ['id' => "\d+"])]
+    #[Route('/{userId}/new', name: 'create', methods: ['GET', 'POST'])]
+    #[Route('/{userId}/edit/{id}', name: 'edit', methods: ['GET', 'POST'], requirements: ['id' => "\d+"])]
     public function addressbookCreate(ManagerRegistry $doctrine, Request $request, int $userId, ?int $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -106,7 +107,8 @@ class AddressBookController extends AbstractController
         ]);
     }
 
-    #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"])]
+    #[Route('/{userId}/delete/{id}', name: 'delete', methods: ['POST'], requirements: ['id' => "\d+"])]
+    #[IsCsrfTokenValid('delete-addressbooks')]
     public function addressbookDelete(ManagerRegistry $doctrine, int $userId, string $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);

--- a/src/Controller/Admin/CalendarController.php
+++ b/src/Controller/Admin/CalendarController.php
@@ -17,12 +17,13 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/calendars', name: 'calendar_')]
 class CalendarController extends AbstractController
 {
-    #[Route('/{userId}', name: 'index')]
+    #[Route('/{userId}', name: 'index', methods: ['GET'])]
     public function calendars(ManagerRegistry $doctrine, UrlGeneratorInterface $router, int $userId): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -75,8 +76,8 @@ class CalendarController extends AbstractController
         ]);
     }
 
-    #[Route('/{userId}/new', name: 'create')]
-    #[Route('/{userId}/edit/{id}', name: 'edit', requirements: ['id' => "\d+"])]
+    #[Route('/{userId}/new', name: 'create', methods: ['GET', 'POST'])]
+    #[Route('/{userId}/edit/{id}', name: 'edit', methods: ['GET', 'POST'], requirements: ['id' => "\d+"])]
     public function calendarEdit(ManagerRegistry $doctrine, Request $request, int $userId, ?int $id, TranslatorInterface $trans): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -170,7 +171,7 @@ class CalendarController extends AbstractController
         ]);
     }
 
-    #[Route('/{userId}/shares/{calendarid}', name: 'shares', requirements: ['calendarid' => "\d+"])]
+    #[Route('/{userId}/shares/{calendarid}', name: 'shares', methods: ['GET'], requirements: ['calendarid' => "\d+"])]
     public function calendarShares(ManagerRegistry $doctrine, int $userId, string $calendarid, TranslatorInterface $trans): Response
     {
         $instances = $doctrine->getRepository(CalendarInstance::class)->findSharedInstancesOfInstance($calendarid, true);
@@ -190,7 +191,8 @@ class CalendarController extends AbstractController
         return new JsonResponse($response);
     }
 
-    #[Route('/{userId}/share/{instanceid}', name: 'share_add', requirements: ['instanceid' => "\d+"])]
+    #[Route('/{userId}/share/{instanceid}', name: 'share_add', methods: ['POST'], requirements: ['instanceid' => "\d+"])]
+    #[IsCsrfTokenValid('calendar-share')]
     public function calendarShareAdd(ManagerRegistry $doctrine, Request $request, int $userId, string $instanceid, TranslatorInterface $trans): Response
     {
         $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($instanceid);
@@ -198,11 +200,11 @@ class CalendarController extends AbstractController
             throw $this->createNotFoundException('Calendar not found');
         }
 
-        if (!is_numeric($request->get('principalId'))) {
+        if (!is_numeric($request->request->get('principalId'))) {
             throw new BadRequestHttpException();
         }
 
-        $newShareeToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->get('principalId'));
+        $newShareeToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->request->get('principalId'));
         if (!$newShareeToAdd) {
             throw $this->createNotFoundException('Member not found');
         }
@@ -211,7 +213,7 @@ class CalendarController extends AbstractController
         // already existing first, so we can update it:
         $existingSharedInstance = $doctrine->getRepository(CalendarInstance::class)->findSharedInstanceOfInstanceFor($instance->getCalendar()->getId(), $newShareeToAdd->getUri());
 
-        $writeAccess = ('true' === $request->get('write') ? SharingPlugin::ACCESS_READWRITE : SharingPlugin::ACCESS_READ);
+        $writeAccess = ('true' === $request->request->get('write') ? SharingPlugin::ACCESS_READWRITE : SharingPlugin::ACCESS_READ);
 
         $entityManager = $doctrine->getManager();
 
@@ -237,7 +239,8 @@ class CalendarController extends AbstractController
         return $this->redirectToRoute('calendar_index', ['userId' => $userId]);
     }
 
-    #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"])]
+    #[Route('/{userId}/delete/{id}', name: 'delete', methods: ['POST'], requirements: ['id' => "\d+"])]
+    #[IsCsrfTokenValid('delete-calendars')]
     public function calendarDelete(ManagerRegistry $doctrine, int $userId, string $id, TranslatorInterface $trans): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -283,7 +286,8 @@ class CalendarController extends AbstractController
         return $this->redirectToRoute('calendar_index', ['userId' => $userId]);
     }
 
-    #[Route('/{userId}/revoke/{id}', name: 'revoke', requirements: ['id' => "\d+"])]
+    #[Route('/{userId}/revoke/{id}', name: 'revoke', methods: ['POST'], requirements: ['id' => "\d+"])]
+    #[IsCsrfTokenValid('delete-revoke')]
     public function calendarRevoke(ManagerRegistry $doctrine, int $userId, string $id, TranslatorInterface $trans): Response
     {
         $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($id);

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class DashboardController extends AbstractController
 {
-    #[Route('/dashboard', name: 'dashboard')]
+    #[Route('/dashboard', name: 'dashboard', methods: ['GET'])]
     public function dashboard(ManagerRegistry $doctrine): Response
     {
         $usersCount = $doctrine->getRepository(User::class)->count([]);

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -17,12 +17,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/users', name: 'user_')]
 class UserController extends AbstractController
 {
-    #[Route('/', name: 'index')]
+    #[Route('/', name: 'index', methods: ['GET'])]
     public function users(ManagerRegistry $doctrine): Response
     {
         $results = $doctrine->getRepository(Principal::class)->findAllMainPrincipalsWithUserIds();
@@ -32,8 +33,8 @@ class UserController extends AbstractController
         ]);
     }
 
-    #[Route('/new', name: 'create')]
-    #[Route('/edit/{userId}', name: 'edit')]
+    #[Route('/new', name: 'create', methods: ['GET', 'POST'])]
+    #[Route('/edit/{userId}', name: 'edit', methods: ['GET', 'POST'])]
     public function userCreate(ManagerRegistry $doctrine, Utils $utils, Request $request, ?int $userId, TranslatorInterface $trans): Response
     {
         if ($userId) {
@@ -124,7 +125,8 @@ class UserController extends AbstractController
         ]);
     }
 
-    #[Route('/delete/{userId}', name: 'delete')]
+    #[Route('/delete/{userId}', name: 'delete', methods: ['POST'])]
+    #[IsCsrfTokenValid('delete-users')]
     public function userDelete(ManagerRegistry $doctrine, int $userId, TranslatorInterface $trans): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -198,7 +200,7 @@ class UserController extends AbstractController
         return $this->redirectToRoute('user_index');
     }
 
-    #[Route('/delegates/{userId}', name: 'delegates')]
+    #[Route('/delegates/{userId}', name: 'delegates', methods: ['GET'])]
     public function userDelegates(ManagerRegistry $doctrine, int $userId): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -226,7 +228,8 @@ class UserController extends AbstractController
         ]);
     }
 
-    #[Route('/delegation/{userId}/{toggle}', name: 'delegation_toggle', requirements: ['toggle' => '(on|off)'])]
+    #[Route('/delegation/{userId}/{toggle}', name: 'delegation_toggle', methods: ['POST'], requirements: ['toggle' => '(on|off)'])]
+    #[IsCsrfTokenValid('delegation-toggle')]
     public function userToggleDelegation(ManagerRegistry $doctrine, int $userId, string $toggle): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
@@ -270,10 +273,11 @@ class UserController extends AbstractController
         return $this->redirectToRoute('user_delegates', ['userId' => $userId]);
     }
 
-    #[Route('/delegates/{userId}/add', name: 'delegate_add')]
+    #[Route('/delegates/{userId}/add', name: 'delegate_add', methods: ['POST'])]
+    #[IsCsrfTokenValid('delegate-add')]
     public function userDelegateAdd(ManagerRegistry $doctrine, Request $request, int $userId): Response
     {
-        if (!is_numeric($request->get('principalId'))) {
+        if (!is_numeric($request->request->get('principalId'))) {
             throw new BadRequestHttpException();
         }
 
@@ -284,14 +288,14 @@ class UserController extends AbstractController
 
         $principalUri = Principal::PREFIX.$user->getUsername();
 
-        $newMemberToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->get('principalId'));
+        $newMemberToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->request->get('principalId'));
 
         if (!$newMemberToAdd) {
             throw $this->createNotFoundException('Member not found');
         }
 
         // Depending on write access or not, attach to the correct principal
-        if ('true' === $request->get('write')) {
+        if ('true' === $request->request->get('write')) {
             // Let's check that there wasn't a read proxy first
             $principalProxyRead = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri.Principal::READ_PROXY_SUFFIX);
             if (!$principalProxyRead) {
@@ -315,8 +319,9 @@ class UserController extends AbstractController
         return $this->redirectToRoute('user_delegates', ['userId' => $userId]);
     }
 
-    #[Route('/delegates/{userId}/remove/{principalProxyId}/{delegateId}', name: 'delegate_remove', requirements: ['principalProxyId' => "\d+", 'delegateId' => "\d+"])]
-    public function userDelegateRemove(ManagerRegistry $doctrine, Request $request, int $userId, int $principalProxyId, int $delegateId): Response
+    #[Route('/delegates/{userId}/remove/{principalProxyId}/{delegateId}', name: 'delegate_remove', methods: ['POST'], requirements: ['principalProxyId' => "\d+", 'delegateId' => "\d+"])]
+    #[IsCsrfTokenValid('delete-delegates')]
+    public function userDelegateRemove(ManagerRegistry $doctrine, int $userId, int $principalProxyId, int $delegateId): Response
     {
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
         if (!$user) {

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -9,7 +9,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController
 {
-    #[Route('/login', name: 'app_login')]
+    #[Route('/login', name: 'app_login', methods: ['GET', 'POST'])]
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         // if ($this->getUser()) {
@@ -24,7 +24,7 @@ class SecurityController extends AbstractController
         return $this->render('security/login.html.twig', ['last_username' => $lastUsername, 'error' => $error]);
     }
 
-    #[Route('/logout', name: 'app_logout')]
+    #[Route('/logout', name: 'app_logout', methods: ['POST'])]
     public function logout()
     {
         throw new \Exception('This method can be blank - it will be intercepted by the logout key on your firewall');

--- a/templates/_partials/add_delegate_modal.html.twig
+++ b/templates/_partials/add_delegate_modal.html.twig
@@ -6,10 +6,11 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ "close"|trans }}"></button>
       </div>
       <div class="modal-body">
-        <form>
+        <form method="post" action="{{ path('user_delegate_add', {userId: userId}) }}" id="addDelegateModal-form">
+          <input type="hidden" name="_token" value="{{ csrf_token('delegate-add') }}">
           <div class="form-group">
-            <label for="member" class="col-form-label">{{ "calendars.delegates.member"|trans }}</label>
-            <select class="form-control" id="addDelegateModal-member">
+            <label for="addDelegateModal-member" class="col-form-label">{{ "calendars.delegates.member"|trans }}</label>
+            <select class="form-control" id="addDelegateModal-member" name="principalId">
               {% for principal in principals %}
                 <option value="{{ principal.id}}">{{ principal.displayName }} ({{ principal.email }})</option>
               {% endfor %}
@@ -17,8 +18,8 @@
             <small class="form-text text-muted">{{ "delegates.member.help"|trans }}</small>
           </div>
           <div class="form-check form-switch mt-2">
-            <input class="form-check-input" type="checkbox" value="" id="addDelegateModal-writeAccess">
-            <label class="form-check-label" for="write">
+            <input class="form-check-input" type="checkbox" name="write" value="true" id="addDelegateModal-writeAccess">
+            <label class="form-check-label" for="addDelegateModal-writeAccess">
               {{ "calendars.delegates.write.give"|trans }}
             </label>
           </div>
@@ -26,7 +27,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ "cancel"|trans }}</button>
-        <a data-href="{{ path('user_delegate_add', {userId: userId}) }}" href="#" class="btn btn-primary" id="addDelegateModal-cta">{{ "add"|trans }}</a>
+        <button type="submit" form="addDelegateModal-form" class="btn btn-primary">{{ "add"|trans }}</button>
       </div>
     </div>
   </div>

--- a/templates/_partials/delegate_row.html.twig
+++ b/templates/_partials/delegate_row.html.twig
@@ -21,6 +21,6 @@
     <p class="mb-1">{{ "users.username"|trans }} : <code>{{ delegate.username }}</code></p>
     <small>{{ "users.uri"|trans }} : <code>{{ delegate.uri }}</code></small>
     <div class="btn-group btn-group-sm mt-3 d-flex d-lg-none" role="group">
-        <a href="#" data-href="{{ path('user_delegate_remove',{userId: userId, principalProxyId: has_write ? principalProxyWrite.id : principalProxyRead.id, delegateId: delegate.id})}}" data-flavour="delegates" class="btn btn-outline-danger flex-fill flex-shrink-1 delete-modal"><span class="d-none d-sm-inline">⚠&nbsp;</span>{{ "remove"|trans }}</a>
+        <a href="#" data-bs-toggle="modal" data-bs-target="#deleteModal-delegates" data-href="{{ path('user_delegate_remove',{userId: userId, principalProxyId: has_write ? principalProxyWrite.id : principalProxyRead.id, delegateId: delegate.id})}}" data-flavour="delegates" class="btn btn-outline-danger flex-fill flex-shrink-1 delete-modal"><span class="d-none d-sm-inline">⚠&nbsp;</span>{{ "remove"|trans }}</a>
     </div>
 </div>

--- a/templates/_partials/delete_modal.html.twig
+++ b/templates/_partials/delete_modal.html.twig
@@ -10,7 +10,10 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ "cancel"|trans }}</button>
-        <a href="#" type="button" class="btn btn-primary" id="deleteModal-{{ flavour }}-cta">{{ "yes"|trans }}</a>
+        <form method="post" id="deleteModal-{{ flavour }}-form">
+          <input type="hidden" name="_token" value="{{ csrf_token('delete-' ~ flavour) }}">
+          <button type="submit" class="btn btn-primary">{{ "yes"|trans }}</button>
+        </form>
       </div>
     </div>
   </div>

--- a/templates/_partials/navigation.html.twig
+++ b/templates/_partials/navigation.html.twig
@@ -22,7 +22,10 @@
             👤 {{ app.user.username }}
           </a>
           <div class="dropdown-menu" aria-labelledby="navUserMenu">
-            <a class="dropdown-item" href="{{ path('app_logout') }}">{{ "logout"|trans }}</a>
+            <form method="post" action="{{ path('app_logout') }}">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token('logout') }}">
+              <button type="submit" class="dropdown-item">{{ "logout"|trans }}</button>
+            </form>
           </div>
         </li>
         <li class="nav-item dropdown">

--- a/templates/_partials/share_modal.html.twig
+++ b/templates/_partials/share_modal.html.twig
@@ -13,15 +13,19 @@
                     <span class="name"></span>
                     <span class="badge bg-info rounded-pill ms-2"></span>
                 </div>
-                <a href="#" class="btn btn-sm btn-danger revoke">{{ "revoke"|trans }}</a>
+                <form method="post" class="revoke">
+                  <input type="hidden" name="_token" value="{{ csrf_token('delete-revoke') }}">
+                  <button type="submit" class="btn btn-sm btn-danger">{{ "revoke"|trans }}</button>
+                </form>
             </div>
         </template>
         <span class="d-none" id="shareModal-none"><em>{{ "calendars.delegates.none"|trans }}</em></span>
         <ul class="list-group" id="shareModal-shares"></ul>
-        <form class="mt-2">
+        <form method="post" class="mt-2" id="shareModal-addForm">
+          <input type="hidden" name="_token" value="{{ csrf_token('calendar-share') }}">
           <div class="form-group">
-            <label for="member" class="col-form-label">{{ "calendars.delegates.member.add"|trans }}</label>
-            <select class="form-control" id="shareModal-member" {% if principals|length == 0 %}disabled="disabled"{% endif %}>
+            <label for="shareModal-member" class="col-form-label">{{ "calendars.delegates.member.add"|trans }}</label>
+            <select class="form-control" id="shareModal-member" name="principalId" {% if principals|length == 0 %}disabled="disabled"{% endif %}>
               {% for principal in principals %}
                 <option value="{{ principal.id}}">{{ principal.displayName }} ({{ principal.email }})</option>
               {% endfor %}
@@ -35,8 +39,8 @@
             </small>
           </div>
           <div class="form-check form-switch mt-2">
-            <input class="form-check-input" type="checkbox" role="switch" value="" id="shareModal-writeAccess" {% if principals|length == 0 %}disabled="disabled"{% endif %}>
-            <label class="form-check-label" for="write">
+            <input class="form-check-input" type="checkbox" role="switch" name="write" value="true" id="shareModal-writeAccess" {% if principals|length == 0 %}disabled="disabled"{% endif %}>
+            <label class="form-check-label" for="shareModal-writeAccess">
               {{ "calendars.delegates.write.give"|trans }}
             </label>
           </div>
@@ -44,7 +48,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ "cancel"|trans }}</button>
-        <a href="#" id="shareModal-addSharee" class="btn btn-primary{% if principals|length == 0 %} disabled{% endif %}">{{ "add"|trans }}</a>
+        <button type="submit" form="shareModal-addForm" class="btn btn-primary" {% if principals|length == 0 %}disabled{% endif %}>{{ "add"|trans }}</button>
       </div>
     </div>
   </div>

--- a/templates/calendars/index.html.twig
+++ b/templates/calendars/index.html.twig
@@ -1,6 +1,10 @@
 {% extends 'base.html.twig' %}
 {% set menu = 'resources' %}
 
+{% macro color_badge(color) %}
+    <span class="badge badge-indicator"{% if color matches '/\\A#[0-9A-Fa-f]{6}(?:[0-9A-Fa-f]{2})?\\z/' %} style="background-color: {{ color }}"{% endif %}>&nbsp;</span>
+{% endmacro %}
+
 {% block body %}
 
 {% include '_partials/back_button.html.twig' with { url: path('user_index'), text: "users.back"|trans } %}
@@ -19,7 +23,7 @@
                     <span class="badge bg-success ml-1">{{ ('calendar.public')|trans }}</span>
                 {% endif %}
                 <a href="#" tabindex="0" class="badge badge-indicator" role="button" data-bs-toggle="popover" data-bs-title="{{ 'calendars.setup.title'|trans }}" data-bs-html='true' data-bs-content="URI: <code>{{ calendar.uri }}</code><br />Absolute path: <code>{{ davUri }}</code>">ⓘ</a>
-                <span class="badge badge-indicator" style="background-color: {{ calendar.calendarColor }}">&nbsp;</span>
+                {{ _self.color_badge(calendar.calendarColor) }}
             </h5>
             <div class="me-0 text-right d-md-block d-none">
                 {% if not calendar.isPublic() %}
@@ -85,7 +89,7 @@
                         <span class="badge bg-info ms-1">{{ ('calendar.share_access.' ~ calendar.access)|trans }}</span>
                     {% endif %}
                     <a href="#" tabindex="0" class="badge badge-indicator ms-1" role="button" data-bs-toggle="popover" data-bs-title="{{ 'calendars.setup.title'|trans }}" data-bs-html='true' data-bs-content="URI: <code>{{ calendar.uri }}</code><br />Absolute path: <code>{{ davUri }}</code>">ⓘ</a>
-                    <span class="badge badge-indicator" style="background-color: {{ calendar.calendarColor }}">&nbsp;</span>
+                    {{ _self.color_badge(calendar.calendarColor) }}
                 </h5>
                 <div class="me-0 text-right d-md-block d-none">
                     <a href="{{ path('calendar_edit',{userId: userId, id: calendar.id})}}" class="btn btn-sm btn-outline-primary ms-1">✎ {{ "edit"|trans }}</a>
@@ -135,7 +139,7 @@
                     {{ calendar.displayName }}
                     <span class="badge bg-warning ms-1">{{ ('calendar.auto')|trans }}</span>
                     <a href="#" tabindex="0" class="badge badge-indicator ms-1" role="button" data-bs-toggle="popover" data-bs-title="{{ 'calendars.setup.title'|trans }}" data-bs-html='true' data-bs-content="URI: <code>{{ calendar.uri }}</code><br />Absolute path: <code>{{ davUri }}</code>">ⓘ</a>
-                    <span class="badge badge-indicator" style="background-color: {{ calendar.calendarColor }}">&nbsp;</span>
+                    {{ _self.color_badge(calendar.calendarColor) }}
                 </h5>
                 <div class="me-0 text-right d-md-block d-none">
                     <a href="{{ path('calendar_edit',{userId: userId, id: calendar.id})}}" class="btn btn-sm btn-outline-primary ms-1">✎ {{ "edit"|trans }}</a>
@@ -168,7 +172,7 @@
                     {{ subscription.displayName }}
                     <span class="badge bg-info ms-1">{{ ('calendar.subscription')|trans }}</span>
                     <a href="#" tabindex="0" class="badge badge-indicator ms-1" role="button" data-bs-toggle="popover" data-bs-title="{{ 'calendars.setup.title'|trans }}" data-bs-html='true' data-bs-content="URI: <code>{{ subscription.uri }}</code>">ⓘ</a>
-                    <span class="badge badge-indicator" style="background-color: {{ subscription.calendarColor }}">&nbsp;</span>
+                    {{ _self.color_badge(subscription.calendarColor) }}
                 </h5>
             </div>
             <code class="mb-1">{{ subscription.source }}</code>

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -5,7 +5,11 @@
 
 {% if app.user %}
     <div class="mb-3">
-        {{ "login.already"|trans({username: app.user.username}) }}, <a href="{{ path('app_logout') }}">{{ "logout"|trans }}</a>
+        {{ "login.already"|trans({username: app.user.username}) }},
+        <form method="post" action="{{ path('app_logout') }}" class="d-inline">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token('logout') }}">
+            <button type="submit" class="btn btn-link p-0 align-baseline">{{ "logout"|trans }}</button>
+        </form>
     </div>
 {% else %}
     <div class="row justify-content-md-center">

--- a/templates/users/delegates.html.twig
+++ b/templates/users/delegates.html.twig
@@ -17,7 +17,10 @@
 {% if delegation %}
     <div class="alert alert-success d-flex justify-content-between mb-4 mt-2" role="alert">
       <div>{{ "delegates.enabled.text"|trans }}<br><small>{{ "delegates.disable.warning"|trans }}</small></div>
-      <a href="{{ path('user_delegation_toggle', {userId: userId, toggle: 'off'})}}" class="btn btn-sm my-auto btn-outline-danger">{{ "delegates.disable"|trans }}</a>
+      <form method="post" action="{{ path('user_delegation_toggle', {userId: userId, toggle: 'off'})}}" class="my-auto">
+        <input type="hidden" name="_token" value="{{ csrf_token('delegation-toggle') }}">
+        <button type="submit" class="btn btn-sm btn-outline-danger">{{ "delegates.disable"|trans }}</button>
+      </form>
     </div>
     {% for delegate in principalProxyRead.delegees %}
         {% include '_partials/delegate_row.html.twig' with {has_write: false} %}
@@ -28,7 +31,11 @@
 
 {% else %}
     <div class="alert alert-warning d-flex justify-content-between mb-4 mt-2" role="alert">
-      {{ "delegates.disabled.text"|trans }}<a href="{{ path('user_delegation_toggle', {userId: userId, toggle: 'on'})}}" class="btn btn-sm my-auto btn-warning">{{ "delegates.enable"|trans }}</a>
+      {{ "delegates.disabled.text"|trans }}
+      <form method="post" action="{{ path('user_delegation_toggle', {userId: userId, toggle: 'on'})}}" class="my-auto">
+        <input type="hidden" name="_token" value="{{ csrf_token('delegation-toggle') }}">
+        <button type="submit" class="btn btn-sm btn-warning">{{ "delegates.enable"|trans }}</button>
+      </form>
     </div>
 {% endif %}
 

--- a/tests/Functional/Controllers/AddressBookControllerTest.php
+++ b/tests/Functional/Controllers/AddressBookControllerTest.php
@@ -107,7 +107,12 @@ class AddressBookControllerTest extends WebTestCase
         $addressbookRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(AddressBook::class);
         $addressbook = $addressbookRepository->findOneByDisplayName('default.addressbook.title');
 
-        $client->request('GET', '/addressbooks/'.$userId.'/delete/'.$addressbook->getId());
+        $crawler = $client->request('GET', '/addressbooks/'.$userId);
+        $csrfToken = $crawler->filter('#deleteModal-addressbooks-form input[name="_token"]')->attr('value');
+
+        $client->request('POST', '/addressbooks/'.$userId.'/delete/'.$addressbook->getId(), [
+            '_token' => $csrfToken,
+        ]);
 
         $this->assertResponseRedirects('/addressbooks/'.$userId);
         $client->followRedirect();

--- a/tests/Functional/Controllers/AdminMutationSecurityTest.php
+++ b/tests/Functional/Controllers/AdminMutationSecurityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Tests\Functional;
+
+use App\Security\AdminUser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class AdminMutationSecurityTest extends WebTestCase
+{
+    public function testAdminMutationsRequirePostAndCsrfProtection(): void
+    {
+        $client = static::createClient();
+
+        $mutations = [
+            'addressbook_delete' => '/addressbooks/1/delete/1',
+            'calendar_share_add' => '/calendars/1/share/1',
+            'calendar_delete' => '/calendars/1/delete/1',
+            'calendar_revoke' => '/calendars/1/revoke/1',
+            'user_delete' => '/users/delete/1',
+            'user_delegation_toggle' => '/users/delegation/1/off',
+            'user_delegate_add' => '/users/delegates/1/add',
+            'user_delegate_remove' => '/users/delegates/1/remove/1/1',
+        ];
+
+        $routes = static::getContainer()->get(RouterInterface::class)->getRouteCollection();
+        foreach ($mutations as $routeName => $path) {
+            $this->assertSame(['POST'], $routes->get($routeName)->getMethods(), $routeName.' is not POST-only');
+
+            $client->loginUser(new AdminUser('admin', 'test'));
+            $client->request('GET', '/dashboard');
+            $this->assertResponseIsSuccessful();
+
+            $client->request('POST', $path);
+            $this->assertResponseRedirects('/login', 302, $path.' accepted a POST request without a CSRF token');
+        }
+    }
+}

--- a/tests/Functional/Controllers/CalendarControllerTest.php
+++ b/tests/Functional/Controllers/CalendarControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\Calendar;
+use App\Entity\CalendarInstance;
 use App\Entity\Principal;
 use App\Entity\User;
 use App\Repository\CalendarInstanceRepository;
@@ -36,6 +38,35 @@ class CalendarControllerTest extends WebTestCase
         $this->assertSelectorTextContains('h1', 'Calendars for Test User');
         $this->assertSelectorTextContains('a.btn', '+ New Calendar');
         $this->assertSelectorTextContains('h5', 'default.calendar.title');
+    }
+
+    public function testCalendarColorsAreSafelyRendered(): void
+    {
+        $client = static::createClient();
+        $client->loginUser(new AdminUser('admin', 'test'));
+
+        $userId = $this->getUserId($client, 'test_user');
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $calendarRepository = $entityManager->getRepository(CalendarInstance::class);
+
+        $calendarRepository->findOneByDisplayName('default.calendar.title')
+            ->setCalendarColor('#00112233');
+
+        $unsafeCalendar = (new CalendarInstance())
+            ->setPrincipalUri(Principal::PREFIX.'test_user')
+            ->setUri('unsafe-color')
+            ->setDisplayName('Unsafe color')
+            ->setCalendarColor('#000;top:0')
+            ->setCalendar(new Calendar());
+        $entityManager->persist($unsafeCalendar);
+        $entityManager->flush();
+
+        $client->request('GET', '/calendars/'.$userId);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('span.badge-indicator[style="background-color: #00112233"]');
+        $this->assertSelectorCount(1, 'span.badge-indicator[style]');
+        $this->assertStringNotContainsString('#000;top:0', $client->getResponse()->getContent());
     }
 
     public function testCalendarEdit(): void

--- a/tests/Functional/Controllers/CalendarControllerTest.php
+++ b/tests/Functional/Controllers/CalendarControllerTest.php
@@ -2,9 +2,11 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\Principal;
 use App\Entity\User;
 use App\Repository\CalendarInstanceRepository;
 use App\Security\AdminUser;
+use Sabre\DAV\Sharing\Plugin as SharingPlugin;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class CalendarControllerTest extends WebTestCase
@@ -108,11 +110,52 @@ class CalendarControllerTest extends WebTestCase
         $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
         $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
 
-        $client->request('GET', '/calendars/'.$userId.'/delete/'.$calendar->getId());
+        $crawler = $client->request('GET', '/calendars/'.$userId);
+        $csrfToken = $crawler->filter('#deleteModal-calendars-form input[name="_token"]')->attr('value');
+
+        $client->request('POST', '/calendars/'.$userId.'/delete/'.$calendar->getId(), [
+            '_token' => $csrfToken,
+        ]);
 
         $this->assertResponseRedirects('/calendars/'.$userId);
         $client->followRedirect();
 
         $this->assertSelectorTextNotContains('h5', 'default.calendar.title');
+    }
+
+    public function testCalendarSharingAndRevocation(): void
+    {
+        $client = static::createClient();
+        $client->loginUser(new AdminUser('admin', 'test'));
+
+        $userId = $this->getUserId($client, 'test_user');
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
+        $sharee = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.'test_user2');
+
+        $crawler = $client->request('GET', '/calendars/'.$userId);
+        $shareToken = $crawler->filter('#shareModal-addForm input[name="_token"]')->attr('value');
+        $revokeToken = $crawler->filter('#shareModal-shareeTemplate input[name="_token"]')->attr('value');
+
+        $client->request('POST', '/calendars/'.$userId.'/share/'.$calendar->getId(), [
+            '_token' => $shareToken,
+            'principalId' => $sharee->getId(),
+            'write' => 'true',
+        ]);
+        $this->assertResponseRedirects('/calendars/'.$userId);
+
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $sharedInstance = $calendarRepository->findSharedInstanceOfInstanceFor($calendar->getCalendar()->getId(), $sharee->getUri());
+        $this->assertNotNull($sharedInstance);
+        $this->assertSame(SharingPlugin::ACCESS_READWRITE, $sharedInstance->getAccess());
+
+        $sharedInstanceId = $sharedInstance->getId();
+        $client->request('POST', '/calendars/'.$userId.'/revoke/'.$sharedInstanceId, [
+            '_token' => $revokeToken,
+        ]);
+        $this->assertResponseRedirects('/calendars/'.$userId);
+
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $this->assertNull($calendarRepository->find($sharedInstanceId));
     }
 }

--- a/tests/Functional/Controllers/DashboardTest.php
+++ b/tests/Functional/Controllers/DashboardTest.php
@@ -2,7 +2,9 @@
 
 namespace App\Tests\Functional;
 
+use App\Security\AdminUser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
 
 class DashboardTest extends WebTestCase
 {
@@ -90,5 +92,23 @@ class DashboardTest extends WebTestCase
         $this->assertSelectorTextContains('h3.objects', 'Objects');
         $this->assertSelectorTextContains('h3.environment', 'Configured environment');
         $this->assertSelectorExists('nav.navbar');
+    }
+
+    public function testLogoutRequiresPostAndCsrfProtection(): void
+    {
+        $client = static::createClient();
+        $client->loginUser(new AdminUser('admin', 'test'));
+
+        $route = static::getContainer()->get(RouterInterface::class)->getRouteCollection()->get('app_logout');
+        $this->assertSame(['POST'], $route->getMethods());
+
+        $crawler = $client->request('GET', '/dashboard');
+        $csrfToken = $crawler->filter('form[action="/logout"] input[name="_csrf_token"]')->attr('value');
+
+        $client->request('POST', '/logout');
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->request('POST', '/logout', ['_csrf_token' => $csrfToken]);
+        $this->assertResponseRedirects('/dashboard');
     }
 }

--- a/tests/Functional/Controllers/UserControllerTest.php
+++ b/tests/Functional/Controllers/UserControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\Principal;
 use App\Entity\User;
 use App\Security\AdminUser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -98,14 +99,21 @@ class UserControllerTest extends WebTestCase
         $userId1 = $this->getUserId($client, 'test_user');
         $userId2 = $this->getUserId($client, 'test_user2');
 
-        $client->request('GET', '/users/delete/'.$userId1);
+        $crawler = $client->request('GET', '/users/');
+        $csrfToken = $crawler->filter('#deleteModal-users-form input[name="_token"]')->attr('value');
+
+        $client->request('POST', '/users/delete/'.$userId1, [
+            '_token' => $csrfToken,
+        ]);
 
         $this->assertResponseRedirects('/users/');
         $client->followRedirect();
 
         $this->assertAnySelectorTextContains('h5', 'Test User 2');
 
-        $client->request('GET', '/users/delete/'.$userId2);
+        $client->request('POST', '/users/delete/'.$userId2, [
+            '_token' => $csrfToken,
+        ]);
 
         $this->assertResponseRedirects('/users/');
         $client->followRedirect();
@@ -128,19 +136,56 @@ class UserControllerTest extends WebTestCase
 
         $this->assertSelectorExists('nav.navbar');
         $this->assertSelectorTextContains('h1', 'Delegates for Test User');
-        $this->assertSelectorTextContains('a.btn', '+ Add a delegate');
+        $this->assertSelectorTextContains('a[data-bs-target="#addDelegateModal"]', '+ Add a delegate');
         $this->assertAnySelectorTextContains('div', 'Delegation is enabled for this account.');
-        $this->assertAnySelectorTextContains('a.btn', 'Disable it');
+        $this->assertAnySelectorTextContains('button.btn', 'Disable it');
 
-        $client->clickLink('Disable it');
+        $client->submitForm('Disable it');
 
         $this->assertResponseRedirects('/users/delegates/'.$userId);
         $client->followRedirect();
 
         $this->assertSelectorExists('nav.navbar');
         $this->assertSelectorTextContains('h1', 'Delegates for Test User');
-        $this->assertSelectorTextNotContains('a.btn', '+ Add a delegate');
+        $this->assertSelectorNotExists('a[data-bs-target="#addDelegateModal"]');
         $this->assertAnySelectorTextContains('div', 'Delegation is not enabled for this account.');
-        $this->assertAnySelectorTextContains('a.btn', 'Enable it');
+        $this->assertAnySelectorTextContains('button.btn', 'Enable it');
+    }
+
+    public function testDelegateAdditionAndRemoval(): void
+    {
+        $client = static::createClient();
+        $client->loginUser(new AdminUser('admin', 'test'));
+
+        $userId = $this->getUserId($client, 'test_user');
+        $principalRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class);
+        $principal = $principalRepository->findOneByUri(Principal::PREFIX.'test_user');
+        $delegate = $principalRepository->findOneByUri(Principal::PREFIX.'test_user2');
+        $readProxy = $principalRepository->findOneByUri($principal->getUri().Principal::READ_PROXY_SUFFIX);
+
+        $crawler = $client->request('GET', '/users/delegates/'.$userId);
+        $addToken = $crawler->filter('#addDelegateModal-form input[name="_token"]')->attr('value');
+        $removeToken = $crawler->filter('#deleteModal-delegates-form input[name="_token"]')->attr('value');
+
+        $client->request('POST', '/users/delegates/'.$userId.'/add', [
+            '_token' => $addToken,
+            'principalId' => $delegate->getId(),
+        ]);
+        $this->assertResponseRedirects('/users/delegates/'.$userId);
+
+        $principalRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class);
+        $readProxy = $principalRepository->find($readProxy->getId());
+        $delegate = $principalRepository->find($delegate->getId());
+        $this->assertTrue($readProxy->getDelegees()->contains($delegate));
+
+        $client->request('POST', '/users/delegates/'.$userId.'/remove/'.$readProxy->getId().'/'.$delegate->getId(), [
+            '_token' => $removeToken,
+        ]);
+        $this->assertResponseRedirects('/users/delegates/'.$userId);
+
+        $principalRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class);
+        $readProxy = $principalRepository->find($readProxy->getId());
+        $delegate = $principalRepository->find($delegate->getId());
+        $this->assertFalse($readProxy->getDelegees()->contains($delegate));
     }
 }


### PR DESCRIPTION
## Why

Several browser-admin actions currently mutate state through unrestricted routes, with some invoked through GET requests. Because these custom actions sit outside Symfony Forms, they also bypass the built-in CSRF protection.

Calendar colors can also be written through DAV without Symfony validation and are rendered directly into inline CSS. SQLite does not enforce the declared `VARCHAR` length, so the database schema does not bound that value.

This PR establishes the standard boundary for the admin interface: reads use GET, form handlers use GET/POST, state-changing actions require POST with a valid CSRF token, and stored calendar colors are allowlisted before entering a CSS context.

The rendering check closes the CSS sink for existing data and every current write path. Validating colors when they are written remains a desirable follow-up so malformed values are rejected instead of being stored inertly.

## What changed

- constrain every browser-admin route to its intended HTTP methods
- require POST and CSRF validation for deletion, sharing, revocation, and delegation changes
- protect logout with POST and Symfony logout CSRF validation
- replace query-string mutation links with ordinary POST forms
- restrict mutation parameters to the POST body
- render calendar and subscription colors only when they exactly match `#RRGGBB` or `#RRGGBBAA`
- omit the inline style for invalid stored colors
- cover both rejected requests and successful share, revoke, delegate, delete, logout, and color-rendering flows

DAV and API endpoints are unchanged; they retain their existing protocol-specific authentication, storage behavior, and HTTP methods.

## Verification

- PHPUnit: 64 tests, 466 assertions
- explicit coverage for every custom admin mutation route
- successful calendar sharing/revocation and delegate addition/removal
- valid calendar colors render unchanged; CSS declarations do not reach the inline style
- Twig, YAML, container, JavaScript, Composer, PHP style, syntax, and whitespace checks
