### PR TITLE
Use numeric DAV sync tokens

### DIFF
--- a/migrations/Version20260720102000.php
+++ b/migrations/Version20260720102000.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260720102000 extends AbstractMigration
+{
+    private const ADDRESSBOOK_SYNC_INDEX = 'idx_addressbookchanges_book_sync';
+
+    public function getDescription(): string
+    {
+        return 'Store DAV sync tokens as integers so range queries use numeric ordering';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $engine = $this->connection->getDatabasePlatform()->getName();
+
+        if ('mysql' === $engine) {
+            $this->addSql('ALTER TABLE addressbooks MODIFY synctoken INT DEFAULT 1 NOT NULL');
+            $this->addSql('ALTER TABLE calendars MODIFY synctoken INT DEFAULT 1 NOT NULL');
+            $this->addSql('ALTER TABLE addressbookchanges MODIFY synctoken INT DEFAULT 1 NOT NULL');
+
+            return;
+        }
+
+        if ('postgresql' === $engine) {
+            foreach (['addressbooks', 'calendars', 'addressbookchanges'] as $table) {
+                $this->addSql(sprintf('ALTER TABLE %s ALTER COLUMN synctoken TYPE INT USING synctoken::integer', $table));
+                $this->addSql(sprintf('ALTER TABLE %s ALTER COLUMN synctoken SET DEFAULT 1', $table));
+            }
+
+            return;
+        }
+
+        if ('sqlite' === $engine) {
+            $restoreSyncIndex = $this->hasAddressBookSyncIndex();
+            if ($restoreSyncIndex) {
+                $this->addSql('DROP INDEX '.self::ADDRESSBOOK_SYNC_INDEX);
+            }
+
+            foreach (['addressbooks', 'calendars', 'addressbookchanges'] as $table) {
+                $this->replaceSqliteSyncToken($table, 'INTEGER', 'INTEGER', '1');
+            }
+
+            if ($restoreSyncIndex) {
+                $this->addSql('CREATE INDEX '.self::ADDRESSBOOK_SYNC_INDEX.' ON addressbookchanges (addressbookid, synctoken)');
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $engine = $this->connection->getDatabasePlatform()->getName();
+
+        if ('mysql' === $engine) {
+            $this->addSql('ALTER TABLE addressbooks MODIFY synctoken VARCHAR(255) NOT NULL');
+            $this->addSql('ALTER TABLE calendars MODIFY synctoken VARCHAR(255) NOT NULL');
+            $this->addSql('ALTER TABLE addressbookchanges MODIFY synctoken VARCHAR(255) NOT NULL');
+
+            return;
+        }
+
+        if ('postgresql' === $engine) {
+            foreach (['addressbooks', 'calendars', 'addressbookchanges'] as $table) {
+                $this->addSql(sprintf('ALTER TABLE %s ALTER COLUMN synctoken DROP DEFAULT', $table));
+                $this->addSql(sprintf('ALTER TABLE %s ALTER COLUMN synctoken TYPE VARCHAR(255) USING synctoken::varchar', $table));
+            }
+
+            return;
+        }
+
+        if ('sqlite' === $engine) {
+            $restoreSyncIndex = $this->hasAddressBookSyncIndex();
+            if ($restoreSyncIndex) {
+                $this->addSql('DROP INDEX '.self::ADDRESSBOOK_SYNC_INDEX);
+            }
+
+            foreach (['addressbooks', 'calendars', 'addressbookchanges'] as $table) {
+                $this->replaceSqliteSyncToken($table, 'VARCHAR(255)', 'TEXT', "'1'");
+            }
+
+            if ($restoreSyncIndex) {
+                $this->addSql('CREATE INDEX '.self::ADDRESSBOOK_SYNC_INDEX.' ON addressbookchanges (addressbookid, synctoken)');
+            }
+        }
+    }
+
+    private function replaceSqliteSyncToken(string $table, string $type, string $cast, string $default): void
+    {
+        $this->addSql(sprintf('ALTER TABLE %s ADD COLUMN new_synctoken %s DEFAULT %s NOT NULL', $table, $type, $default));
+        $this->addSql(sprintf('UPDATE %s SET new_synctoken = CAST(synctoken AS %s)', $table, $cast));
+        $this->addSql(sprintf('ALTER TABLE %s RENAME COLUMN synctoken TO old_synctoken', $table));
+        $this->addSql(sprintf('ALTER TABLE %s RENAME COLUMN new_synctoken TO synctoken', $table));
+        $this->addSql(sprintf('ALTER TABLE %s DROP COLUMN old_synctoken', $table));
+    }
+
+    private function hasAddressBookSyncIndex(): bool
+    {
+        $indexes = array_change_key_case(
+            $this->connection->createSchemaManager()->listTableIndexes('addressbookchanges'),
+            CASE_LOWER,
+        );
+
+        return isset($indexes[self::ADDRESSBOOK_SYNC_INDEX]);
+    }
+}

--- a/src/Entity/AddressBook.php
+++ b/src/Entity/AddressBook.php
@@ -31,7 +31,7 @@ class AddressBook
     #[ORM\Column(type: 'text', nullable: true)]
     private $description;
 
-    #[ORM\Column(type: 'string', length: 255)]
+    #[ORM\Column(type: 'integer', options: ['default' => 1])]
     private $synctoken;
 
     #[ORM\Column(type: 'boolean', nullable: true, options: ['default' => false])]
@@ -116,12 +116,12 @@ class AddressBook
         return $this;
     }
 
-    public function getSynctoken(): ?string
+    public function getSynctoken(): ?int
     {
         return $this->synctoken;
     }
 
-    public function setSynctoken(string $synctoken): self
+    public function setSynctoken(int $synctoken): self
     {
         $this->synctoken = $synctoken;
 

--- a/src/Entity/AddressBookChange.php
+++ b/src/Entity/AddressBookChange.php
@@ -16,7 +16,7 @@ class AddressBookChange
     #[ORM\Column(type: 'string', length: 255)]
     private $uri;
 
-    #[ORM\Column(type: 'string', length: 255)]
+    #[ORM\Column(type: 'integer', options: ['default' => 1])]
     private $synctoken;
 
     #[ORM\ManyToOne(targetEntity: "App\Entity\AddressBook", inversedBy: 'changes')]
@@ -43,12 +43,12 @@ class AddressBookChange
         return $this;
     }
 
-    public function getSynctoken(): ?string
+    public function getSynctoken(): ?int
     {
         return $this->synctoken;
     }
 
-    public function setSynctoken(string $synctoken): self
+    public function setSynctoken(int $synctoken): self
     {
         $this->synctoken = $synctoken;
 

--- a/src/Entity/Calendar.php
+++ b/src/Entity/Calendar.php
@@ -19,7 +19,7 @@ class Calendar
     #[ORM\Column(type: 'integer')]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255)]
+    #[ORM\Column(type: 'integer', options: ['default' => 1])]
     private $synctoken;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
@@ -47,12 +47,12 @@ class Calendar
         return $this->id;
     }
 
-    public function getSynctoken(): ?string
+    public function getSynctoken(): ?int
     {
         return $this->synctoken;
     }
 
-    public function setSynctoken(string $synctoken): self
+    public function setSynctoken(int $synctoken): self
     {
         $this->synctoken = $synctoken;
 

--- a/tests/Functional/Commands/SyncBirthdayCalendarTest.php
+++ b/tests/Functional/Commands/SyncBirthdayCalendarTest.php
@@ -71,7 +71,7 @@ class SyncBirthdayCalendarTest extends KernelTestCase
             ->setUri('default')
             ->setDisplayName('Default')
             ->setDescription('')
-            ->setSynctoken('1')
+            ->setSynctoken(1)
             ->setIncludedInBirthdayCalendar(true);
         $this->em->persist($addressBook);
 

--- a/tests/Functional/Service/BirthdayServiceTest.php
+++ b/tests/Functional/Service/BirthdayServiceTest.php
@@ -54,7 +54,7 @@ class BirthdayServiceTest extends KernelTestCase
             ->setUri('default')
             ->setDisplayName('Default')
             ->setDescription('')
-            ->setSynctoken('1')
+            ->setSynctoken(1)
             ->setIncludedInBirthdayCalendar($includedInBirthdayCalendar);
         $this->em->persist($addressBook);
         $this->em->flush();

--- a/tests/Functional/SyncTokenTest.php
+++ b/tests/Functional/SyncTokenTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sabre\CardDAV\Backend\PDO as CardDavBackend;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SyncTokenTest extends KernelTestCase
+{
+    public function testAddressBookChangesUseNumericTokenOrdering(): void
+    {
+        self::bootKernel();
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $pdo = $entityManager->getConnection()->getNativeConnection();
+
+        $statement = $pdo->prepare(<<<'SQL'
+INSERT INTO addressbooks (principaluri, displayname, uri, description, synctoken)
+VALUES (?, ?, ?, ?, ?)
+SQL);
+        $statement->execute(['principals/sync-token-test', 'Sync token test', 'sync-token-test', '', 11]);
+
+        $statement = $pdo->prepare('SELECT id FROM addressbooks WHERE principaluri = ? AND uri = ?');
+        $statement->execute(['principals/sync-token-test', 'sync-token-test']);
+        $addressBookId = (int) $statement->fetchColumn();
+
+        $statement = $pdo->prepare(<<<'SQL'
+INSERT INTO addressbookchanges (addressbookid, uri, synctoken, operation)
+VALUES (?, ?, ?, ?)
+SQL);
+        $statement->execute([$addressBookId, 'added.vcf', 9, 1]);
+        $statement->execute([$addressBookId, 'changed.vcf', 10, 2]);
+
+        $changes = (new CardDavBackend($pdo))->getChangesForAddressBook($addressBookId, '9', 1);
+
+        self::assertSame(11, (int) $changes['syncToken']);
+        self::assertSame(['added.vcf'], $changes['added']);
+        self::assertSame(['changed.vcf'], $changes['modified']);
+        self::assertSame([], $changes['deleted']);
+    }
+}


### PR DESCRIPTION
## Why

SabreDAV performs numeric range comparisons and ordering on sync tokens. Davis stores the CardDAV parent and change tokens as strings, so a request spanning a decimal-width boundary can be evaluated lexically: token `10` sorts before token `9`.

In practice, an incremental address-book sync starting at token 9 can return no changes after the collection advances through 10. The problem is visible on SQLite and applies to the string-backed schema on MariaDB and PostgreSQL as well.

Sync tokens are generated and incremented numerically by SabreDAV. Their database and entity types should reflect that invariant.

## What changed

- store calendar, address-book, and address-book-change sync tokens as integers
- migrate SQLite, MariaDB, and PostgreSQL without deleting or rewriting DAV resources
- preserve and rebuild the compound address-book sync index when it already exists during the SQLite column replacement
- make entity accessors consistently typed as integers
- add a backend regression covering changes at tokens 9 and 10

The migration version intentionally precedes the companion index migration, but it also handles installations that apply the index PR first.

## Verification

- SQLite: existing token data preserved across migration up/down/up, integer affinity verified, and the 9-to-10 range returns both changes
- MariaDB 10.11: fresh migration, exact Doctrine schema validation, migration down/up, and 60 tests / 410 assertions
- PostgreSQL 15: integer conversion, defaults, numeric range behavior, and rollback syntax exercised directly
- combined with the pending SQLite and index work: 61 tests / 414 assertions