### PR TITLE
Security fixes

### DIFF
--- a/docs/api/v1/calendars/delete.md
+++ b/docs/api/v1/calendars/delete.md
@@ -12,8 +12,15 @@ Deletes a specific calendar for a specific user.
 
 ```
 :user_id -> "[user id as an int]",
-:calendar_id -> "[numeric id of a calendar owned by the user]",
+:calendar_id -> "[numeric id of a calendar instance belonging to the user]",
 ```
+
+If the calendar is owned by the user, the calendar, its events, its change log, its scheduling objects and every
+instance shared with other users are deleted. The user's calendar subscriptions and unrelated inbox items are left
+untouched.
+
+If the calendar was merely *shared with* the user, only the user's access to it is removed (the owner's calendar
+and events are kept).
 
 **URL example**
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,25 +1,60 @@
 'use strict'
 
+// State-changing admin actions are sent as POST requests carrying the CSRF token
+// exposed in the <meta name="csrf-token"> tag of the layout.
+function postTo(url, params = {}) {
+    const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = url;
+    form.classList.add('d-none');
+
+    const fields = Object.assign({ _token: token }, params);
+    Object.keys(fields).forEach(name => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.value = fields[name];
+        form.appendChild(input);
+    });
+
+    document.body.appendChild(form);
+    form.submit();
+}
+
+// Any element with a data-post-href attribute triggers a POST to that URL when clicked
+document.addEventListener('click', event => {
+    const trigger = event.target.closest('[data-post-href]');
+    if (!trigger) {
+        return;
+    }
+
+    event.preventDefault();
+    postTo(trigger.getAttribute('data-post-href'));
+});
+
 // Calendar share modal
 const shareModal = document.getElementById('shareModal')
 if (shareModal) {
+    const addShareeButton = document.getElementById('shareModal-addSharee');
+
+    // Bound once: the target url is refreshed each time the modal is shown
+    addShareeButton.addEventListener("click", function(e) {
+        const writeAccess = document.getElementById('shareModal-writeAccess').checked ? 'true' : 'false';
+        const principalId = document.getElementById('shareModal-member').value;
+
+        e.preventDefault()
+        postTo(addShareeButton.getAttribute('data-href'), { principalId: principalId, write: writeAccess })
+    });
+
     shareModal.addEventListener('show.bs.modal', event => {
         // Button that triggered the modal
         const button = event.relatedTarget
 
         // Grab calendar shares url and add url
         let shareesUrl = button.getAttribute('data-sharees-href');
-        let targetUrl = button.getAttribute('data-href');
-
-        // When adding the sharee, catch the click to add the query parameter
-        const addShareeButton = document.getElementById('shareModal-addSharee');
-        addShareeButton.addEventListener("click", function(e) {
-            const writeAccess = document.getElementById('shareModal-writeAccess').checked ? 'true' : 'false';
-            const principalId = document.getElementById('shareModal-member').value;
-
-            e.preventDefault()
-            window.location = targetUrl + "?principalId=" + principalId + "&write=" + writeAccess
-        });
+        addShareeButton.setAttribute('data-href', button.getAttribute('data-href'));
 
         const noneElement = document.getElementById('shareModal-none')
 
@@ -37,7 +72,7 @@ if (shareModal) {
                     noneElement.classList.remove("d-none");
                     return
                 }
-    
+
                 noneElement.classList.add('d-none')
 
                 // Share list item template
@@ -53,20 +88,19 @@ if (shareModal) {
                         badge[0].classList.add('bg-success')
                         badge[0].classList.remove('bg-info')
                     }
-                    let revokeButton = clone.querySelectorAll("a.revoke");
-                    revokeButton[0].href = element.revokeUrl;
+                    let revokeButton = clone.querySelectorAll(".revoke");
+                    revokeButton[0].setAttribute('data-post-href', element.revokeUrl);
 
                     shares.appendChild(clone);
                 });
-                
+
             });
     })
 }
 
 
 // Delete modals (all kind of entities, so we use the rel, not the id)
-const deleteModals = document.querySelectorAll('[rel="deleteModal"]');
-deleteModals.forEach(element => {
+document.querySelectorAll('[rel="deleteModal"]').forEach(element => {
     element.addEventListener('show.bs.modal', event => {
         // Button that triggered the modal
         const button = event.relatedTarget
@@ -75,31 +109,25 @@ deleteModals.forEach(element => {
         let targetUrl = button.getAttribute('data-href');
         let modalFlavour = button.getAttribute('data-flavour');
 
-        // Put it into the modal's OK button
+        // Put it into the modal's OK button (which POSTs it on click)
         const deleteCTA = document.getElementById(`deleteModal-${modalFlavour}-cta`);
-        console.log("setting href to " + targetUrl)
-        deleteCTA.setAttribute('href', targetUrl);
+        deleteCTA.setAttribute('data-post-href', targetUrl);
     })
 })
-
 
 
 // Global account delegation modal
 const addDelegateModal = document.getElementById('addDelegateModal')
 if (addDelegateModal) {
-    addDelegateModal.addEventListener('show.bs.modal', event => {
-        // When adding the sharee, catch the click to add the query parameter
-        const addDelegateButton = document.getElementById('addDelegateModal-cta');
-        addDelegateButton.addEventListener("click", function(e) {
-            const targetUrl = addDelegateButton.getAttribute('data-href');
-            const writeAccess = document.getElementById('addDelegateModal-writeAccess').checked ? 'true' : 'false';
-            const principalId = document.getElementById('addDelegateModal-member').value;
+    const addDelegateButton = document.getElementById('addDelegateModal-cta');
+    addDelegateButton.addEventListener("click", function(e) {
+        const targetUrl = addDelegateButton.getAttribute('data-href');
+        const writeAccess = document.getElementById('addDelegateModal-writeAccess').checked ? 'true' : 'false';
+        const principalId = document.getElementById('addDelegateModal-member').value;
 
-            e.preventDefault()
-            window.location = targetUrl + "?principalId=" + principalId + "&write=" + writeAccess
-        });
-
-    })
+        e.preventDefault()
+        postTo(targetUrl, { principalId: principalId, write: writeAccess })
+    });
 }
 
 // Color swatch: update it live (not working in IE ¯\_(ツ)_/¯ but it's just a nice to have)

--- a/src/Controller/Admin/AddressBookController.php
+++ b/src/Controller/Admin/AddressBookController.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Form\AddressBookType;
 use App\Services\BirthdayService;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,15 +19,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class AddressBookController extends AbstractController
 {
     #[Route('/{userId}', name: 'index')]
-    public function addressBooks(ManagerRegistry $doctrine, int $userId): Response
+    public function addressBooks(ManagerRegistry $doctrine, #[MapEntity(id: 'userId')] User $user, int $userId): Response
     {
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
-        $username = $user->getUsername();
-        $principalUri = Principal::PREFIX.$username;
+        $principalUri = $user->getPrincipalUri();
 
         $principal = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri);
         $addressbooks = $doctrine->getRepository(AddressBook::class)->findByPrincipalUri($principalUri);
@@ -40,15 +35,10 @@ class AddressBookController extends AbstractController
 
     #[Route('/{userId}/new', name: 'create')]
     #[Route('/{userId}/edit/{id}', name: 'edit', requirements: ['id' => "\d+"])]
-    public function addressbookCreate(ManagerRegistry $doctrine, Request $request, int $userId, ?int $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
+    public function addressbookCreate(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, ?int $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
     {
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
         $username = $user->getUsername();
-        $principalUri = Principal::PREFIX.$username;
+        $principalUri = $user->getPrincipalUri();
 
         $principal = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri);
 
@@ -57,12 +47,14 @@ class AddressBookController extends AbstractController
         }
 
         if ($id) {
-            $addressbook = $doctrine->getRepository(AddressBook::class)->findOneById($id);
+            $addressbook = $doctrine->getRepository(AddressBook::class)->findOneBy(['id' => $id, 'principalUri' => $principalUri]);
             if (!$addressbook) {
                 throw $this->createNotFoundException('Address book not found');
             }
         } else {
             $addressbook = new AddressBook();
+            // The owner is given by the URL, never by the submitted form
+            $addressbook->setPrincipalUri($principalUri);
         }
 
         $isBirthdayCalendarEnabled = $this->getParameter('caldav_enabled') && $this->getParameter('carddav_enabled');
@@ -72,8 +64,6 @@ class AddressBookController extends AbstractController
         if ($isBirthdayCalendarEnabled) {
             $form->get('includedInBirthdayCalendar')->setData($addressbook->isIncludedInBirthdayCalendar());
         }
-        $form->get('principalUri')->setData($principalUri);
-
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -107,18 +97,16 @@ class AddressBookController extends AbstractController
     }
 
     #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"], methods: ['POST'])]
-    public function addressbookDelete(ManagerRegistry $doctrine, Request $request, int $userId, string $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
+    public function addressbookDelete(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, string $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
+        $username = $user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
-        $addressbook = $doctrine->getRepository(AddressBook::class)->findOneById($id);
+        $addressbook = $doctrine->getRepository(AddressBook::class)->findOneBy(['id' => $id, 'principalUri' => $principalUri]);
         if (!$addressbook) {
             throw $this->createNotFoundException('Address Book not found');
         }
@@ -139,7 +127,7 @@ class AddressBookController extends AbstractController
         $isBirthdayCalendarEnabled = $this->getParameter('caldav_enabled') && $this->getParameter('carddav_enabled');
         if ($isBirthdayCalendarEnabled) {
             // Let's sync the user birthday calendar if needed
-            $birthdayService->syncUser($user->getUsername());
+            $birthdayService->syncUser($username);
         }
 
         return $this->redirectToRoute('addressbook_index', ['userId' => $userId]);

--- a/src/Controller/Admin/AddressBookController.php
+++ b/src/Controller/Admin/AddressBookController.php
@@ -106,9 +106,13 @@ class AddressBookController extends AbstractController
         ]);
     }
 
-    #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"])]
-    public function addressbookDelete(ManagerRegistry $doctrine, int $userId, string $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
+    #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"], methods: ['POST'])]
+    public function addressbookDelete(ManagerRegistry $doctrine, Request $request, int $userId, string $id, TranslatorInterface $trans, BirthdayService $birthdayService): Response
     {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
         if (!$user) {
             throw $this->createNotFoundException('User not found');

--- a/src/Controller/Admin/CalendarController.php
+++ b/src/Controller/Admin/CalendarController.php
@@ -10,6 +10,7 @@ use App\Entity\User;
 use App\Form\CalendarInstanceType;
 use Doctrine\Persistence\ManagerRegistry;
 use Sabre\DAV\Sharing\Plugin as SharingPlugin;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,15 +24,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class CalendarController extends AbstractController
 {
     #[Route('/{userId}', name: 'index')]
-    public function calendars(ManagerRegistry $doctrine, UrlGeneratorInterface $router, int $userId): Response
+    public function calendars(ManagerRegistry $doctrine, UrlGeneratorInterface $router, #[MapEntity(id: 'userId')] User $user, int $userId): Response
     {
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
         $username = $user->getUsername();
-        $principalUri = Principal::PREFIX.$username;
+        $principalUri = $user->getPrincipalUri();
 
         $principal = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri);
         $allCalendars = $doctrine->getRepository(CalendarInstance::class)->findByPrincipalUri($principalUri);
@@ -77,15 +73,9 @@ class CalendarController extends AbstractController
 
     #[Route('/{userId}/new', name: 'create')]
     #[Route('/{userId}/edit/{id}', name: 'edit', requirements: ['id' => "\d+"])]
-    public function calendarEdit(ManagerRegistry $doctrine, Request $request, int $userId, ?int $id, TranslatorInterface $trans): Response
+    public function calendarEdit(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, ?int $id, TranslatorInterface $trans): Response
     {
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
-        $username = $user->getUsername();
-        $principalUri = Principal::PREFIX.$username;
+        $principalUri = $user->getPrincipalUri();
 
         $principal = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri);
 
@@ -94,7 +84,7 @@ class CalendarController extends AbstractController
         }
 
         if ($id) {
-            $calendarInstance = $doctrine->getRepository(CalendarInstance::class)->findOneById($id);
+            $calendarInstance = $doctrine->getRepository(CalendarInstance::class)->findOneForPrincipal($id, $principalUri);
             if (!$calendarInstance) {
                 throw $this->createNotFoundException('Calendar not found');
             }
@@ -102,6 +92,8 @@ class CalendarController extends AbstractController
             $calendarInstance = new CalendarInstance();
             $calendar = new Calendar();
             $calendarInstance->setCalendar($calendar);
+            // The owner is given by the URL, never by the submitted form
+            $calendarInstance->setPrincipalUri($principalUri);
         }
 
         $arePublicCalendarsEnabled = $this->getParameter('public_calendars_enabled');
@@ -117,7 +109,6 @@ class CalendarController extends AbstractController
         $form->get('events')->setData(in_array(Calendar::COMPONENT_EVENTS, $components));
         $form->get('todos')->setData(in_array(Calendar::COMPONENT_TODOS, $components));
         $form->get('notes')->setData(in_array(Calendar::COMPONENT_NOTES, $components));
-        $form->get('principalUri')->setData($principalUri);
 
         $form->handleRequest($request);
 
@@ -171,8 +162,14 @@ class CalendarController extends AbstractController
     }
 
     #[Route('/{userId}/shares/{calendarid}', name: 'shares', requirements: ['calendarid' => "\d+"])]
-    public function calendarShares(ManagerRegistry $doctrine, int $userId, string $calendarid, TranslatorInterface $trans): Response
+    public function calendarShares(ManagerRegistry $doctrine, #[MapEntity(id: 'userId')] User $user, int $userId, string $calendarid, TranslatorInterface $trans): Response
     {
+        $principalUri = $user->getPrincipalUri();
+
+        if (!$doctrine->getRepository(CalendarInstance::class)->findOwnerInstanceOfCalendarForPrincipal((int) $calendarid, $principalUri)) {
+            throw $this->createNotFoundException('Calendar not found');
+        }
+
         $instances = $doctrine->getRepository(CalendarInstance::class)->findSharedInstancesOfInstance($calendarid, true);
 
         $response = [];
@@ -191,14 +188,17 @@ class CalendarController extends AbstractController
     }
 
     #[Route('/{userId}/share/{instanceid}', name: 'share_add', requirements: ['instanceid' => "\d+"], methods: ['POST'])]
-    public function calendarShareAdd(ManagerRegistry $doctrine, Request $request, int $userId, string $instanceid, TranslatorInterface $trans): Response
+    public function calendarShareAdd(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, string $instanceid, TranslatorInterface $trans): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($instanceid);
-        if (!$instance) {
+        $principalUri = $user->getPrincipalUri();
+
+        // Only the owner of a calendar can share it
+        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneForPrincipal((int) $instanceid, $principalUri);
+        if (!$instance || $instance->isShared()) {
             throw $this->createNotFoundException('Calendar not found');
         }
 
@@ -209,6 +209,9 @@ class CalendarController extends AbstractController
         $newShareeToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->request->get('principalId'));
         if (!$newShareeToAdd) {
             throw $this->createNotFoundException('Member not found');
+        }
+        if ($newShareeToAdd->getUri() === $principalUri) {
+            throw new BadRequestHttpException('A calendar cannot be shared with its owner');
         }
 
         // Let's check that there wasn't another instance
@@ -242,24 +245,29 @@ class CalendarController extends AbstractController
     }
 
     #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"], methods: ['POST'])]
-    public function calendarDelete(ManagerRegistry $doctrine, Request $request, int $userId, string $id, TranslatorInterface $trans): Response
+    public function calendarDelete(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, string $id, TranslatorInterface $trans): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
-        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($id);
+        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneForPrincipal((int) $id, $principalUri);
         if (!$instance) {
             throw $this->createNotFoundException('Calendar not found');
         }
 
         $entityManager = $doctrine->getManager();
+
+        // A calendar shared *with* this user is not theirs to delete: only drop their access to it
+        if ($instance->isShared()) {
+            $entityManager->remove($instance);
+            $entityManager->flush();
+            $this->addFlash('success', $trans->trans('calendar.revoked'));
+
+            return $this->redirectToRoute('calendar_index', ['userId' => $userId]);
+        }
 
         // Scheduling objects attached to the calendar objects of the calendar
         $schedulingObjectsOfCalendarObjects = $doctrine->getRepository(CalendarInstance::class)->findAllSchedulingObjectsForCalendar($instance->getId(), $principalUri);
@@ -292,15 +300,30 @@ class CalendarController extends AbstractController
     }
 
     #[Route('/{userId}/revoke/{id}', name: 'revoke', requirements: ['id' => "\d+"], methods: ['POST'])]
-    public function calendarRevoke(ManagerRegistry $doctrine, Request $request, int $userId, string $id, TranslatorInterface $trans): Response
+    public function calendarRevoke(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, string $id, TranslatorInterface $trans): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($id);
+        $principalUri = $user->getPrincipalUri();
+
+        $repository = $doctrine->getRepository(CalendarInstance::class);
+        $instance = $repository->find((int) $id);
         if (!$instance) {
             throw $this->createNotFoundException('Calendar not found');
+        }
+
+        // A share can be revoked by the sharee (from their own page) or by an owner of the calendar
+        $isSharee = $instance->getPrincipalUri() === $principalUri;
+        $isOwner = null !== $repository->findOwnerInstanceOfCalendarForPrincipal($instance->getCalendar()->getId(), $principalUri);
+        if (!$isSharee && !$isOwner) {
+            throw $this->createNotFoundException('Calendar not found');
+        }
+
+        // Revoking an owner's own instance would orphan the calendar
+        if (!$instance->isShared()) {
+            throw new BadRequestHttpException('Only a shared calendar can be revoked');
         }
 
         $entityManager = $doctrine->getManager();

--- a/src/Controller/Admin/CalendarController.php
+++ b/src/Controller/Admin/CalendarController.php
@@ -190,19 +190,23 @@ class CalendarController extends AbstractController
         return new JsonResponse($response);
     }
 
-    #[Route('/{userId}/share/{instanceid}', name: 'share_add', requirements: ['instanceid' => "\d+"])]
+    #[Route('/{userId}/share/{instanceid}', name: 'share_add', requirements: ['instanceid' => "\d+"], methods: ['POST'])]
     public function calendarShareAdd(ManagerRegistry $doctrine, Request $request, int $userId, string $instanceid, TranslatorInterface $trans): Response
     {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
         $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($instanceid);
         if (!$instance) {
             throw $this->createNotFoundException('Calendar not found');
         }
 
-        if (!is_numeric($request->get('principalId'))) {
+        if (!is_numeric($request->request->get('principalId'))) {
             throw new BadRequestHttpException();
         }
 
-        $newShareeToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->get('principalId'));
+        $newShareeToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->request->get('principalId'));
         if (!$newShareeToAdd) {
             throw $this->createNotFoundException('Member not found');
         }
@@ -211,7 +215,7 @@ class CalendarController extends AbstractController
         // already existing first, so we can update it:
         $existingSharedInstance = $doctrine->getRepository(CalendarInstance::class)->findSharedInstanceOfInstanceFor($instance->getCalendar()->getId(), $newShareeToAdd->getUri());
 
-        $writeAccess = ('true' === $request->get('write') ? SharingPlugin::ACCESS_READWRITE : SharingPlugin::ACCESS_READ);
+        $writeAccess = ('true' === $request->request->get('write') ? SharingPlugin::ACCESS_READWRITE : SharingPlugin::ACCESS_READ);
 
         $entityManager = $doctrine->getManager();
 
@@ -237,9 +241,13 @@ class CalendarController extends AbstractController
         return $this->redirectToRoute('calendar_index', ['userId' => $userId]);
     }
 
-    #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"])]
-    public function calendarDelete(ManagerRegistry $doctrine, int $userId, string $id, TranslatorInterface $trans): Response
+    #[Route('/{userId}/delete/{id}', name: 'delete', requirements: ['id' => "\d+"], methods: ['POST'])]
+    public function calendarDelete(ManagerRegistry $doctrine, Request $request, int $userId, string $id, TranslatorInterface $trans): Response
     {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
         if (!$user) {
             throw $this->createNotFoundException('User not found');
@@ -283,9 +291,13 @@ class CalendarController extends AbstractController
         return $this->redirectToRoute('calendar_index', ['userId' => $userId]);
     }
 
-    #[Route('/{userId}/revoke/{id}', name: 'revoke', requirements: ['id' => "\d+"])]
-    public function calendarRevoke(ManagerRegistry $doctrine, int $userId, string $id, TranslatorInterface $trans): Response
+    #[Route('/{userId}/revoke/{id}', name: 'revoke', requirements: ['id' => "\d+"], methods: ['POST'])]
+    public function calendarRevoke(ManagerRegistry $doctrine, Request $request, int $userId, string $id, TranslatorInterface $trans): Response
     {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
         $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($id);
         if (!$instance) {
             throw $this->createNotFoundException('Calendar not found');

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -124,9 +124,13 @@ class UserController extends AbstractController
         ]);
     }
 
-    #[Route('/delete/{userId}', name: 'delete')]
-    public function userDelete(ManagerRegistry $doctrine, int $userId, TranslatorInterface $trans): Response
+    #[Route('/delete/{userId}', name: 'delete', methods: ['POST'])]
+    public function userDelete(ManagerRegistry $doctrine, Request $request, int $userId, TranslatorInterface $trans): Response
     {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
         if (!$user) {
             throw $this->createNotFoundException('User not found');
@@ -226,9 +230,13 @@ class UserController extends AbstractController
         ]);
     }
 
-    #[Route('/delegation/{userId}/{toggle}', name: 'delegation_toggle', requirements: ['toggle' => '(on|off)'])]
-    public function userToggleDelegation(ManagerRegistry $doctrine, int $userId, string $toggle): Response
+    #[Route('/delegation/{userId}/{toggle}', name: 'delegation_toggle', requirements: ['toggle' => '(on|off)'], methods: ['POST'])]
+    public function userToggleDelegation(ManagerRegistry $doctrine, Request $request, int $userId, string $toggle): Response
     {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
         if (!$user) {
             throw $this->createNotFoundException('User not found');
@@ -270,10 +278,14 @@ class UserController extends AbstractController
         return $this->redirectToRoute('user_delegates', ['userId' => $userId]);
     }
 
-    #[Route('/delegates/{userId}/add', name: 'delegate_add')]
+    #[Route('/delegates/{userId}/add', name: 'delegate_add', methods: ['POST'])]
     public function userDelegateAdd(ManagerRegistry $doctrine, Request $request, int $userId): Response
     {
-        if (!is_numeric($request->get('principalId'))) {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        if (!is_numeric($request->request->get('principalId'))) {
             throw new BadRequestHttpException();
         }
 
@@ -284,14 +296,14 @@ class UserController extends AbstractController
 
         $principalUri = Principal::PREFIX.$user->getUsername();
 
-        $newMemberToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->get('principalId'));
+        $newMemberToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->request->get('principalId'));
 
         if (!$newMemberToAdd) {
             throw $this->createNotFoundException('Member not found');
         }
 
         // Depending on write access or not, attach to the correct principal
-        if ('true' === $request->get('write')) {
+        if ('true' === $request->request->get('write')) {
             // Let's check that there wasn't a read proxy first
             $principalProxyRead = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri.Principal::READ_PROXY_SUFFIX);
             if (!$principalProxyRead) {
@@ -315,9 +327,13 @@ class UserController extends AbstractController
         return $this->redirectToRoute('user_delegates', ['userId' => $userId]);
     }
 
-    #[Route('/delegates/{userId}/remove/{principalProxyId}/{delegateId}', name: 'delegate_remove', requirements: ['principalProxyId' => "\d+", 'delegateId' => "\d+"])]
+    #[Route('/delegates/{userId}/remove/{principalProxyId}/{delegateId}', name: 'delegate_remove', requirements: ['principalProxyId' => "\d+", 'delegateId' => "\d+"], methods: ['POST'])]
     public function userDelegateRemove(ManagerRegistry $doctrine, Request $request, int $userId, int $principalProxyId, int $delegateId): Response
     {
+        if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
         $user = $doctrine->getRepository(User::class)->findOneById($userId);
         if (!$user) {
             throw $this->createNotFoundException('User not found');

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -12,6 +12,7 @@ use App\Entity\User;
 use App\Form\UserType;
 use App\Services\Utils;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,7 +43,7 @@ class UserController extends AbstractController
                 throw $this->createNotFoundException('User not found');
             }
             $oldHash = $user->getPassword();
-            $principal = $doctrine->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.$user->getUsername());
+            $principal = $doctrine->getRepository(Principal::class)->findOneByUri($user->getPrincipalUri());
         } else {
             $user = new User();
             $principal = new Principal();
@@ -74,11 +75,11 @@ class UserController extends AbstractController
 
             // If it's a new user, create default calendar and address book, and principal
             if (null === $user->getId()) {
-                $principal->setUri(Principal::PREFIX.$user->getUsername());
+                $principal->setUri($user->getPrincipalUri());
 
                 $calendarInstance = new CalendarInstance();
                 $calendar = new Calendar();
-                $calendarInstance->setPrincipalUri(Principal::PREFIX.$user->getUsername())
+                $calendarInstance->setPrincipalUri($user->getPrincipalUri())
                          ->setUri('default') // No risk of collision since unicity is guaranteed by the new user principal
                          ->setDisplayName($trans->trans('default.calendar.title'))
                          ->setDescription($trans->trans('default.calendar.description', ['user' => $displayName]))
@@ -96,7 +97,7 @@ class UserController extends AbstractController
                 $entityManager->persist($principalProxyWrite);
 
                 $addressbook = new AddressBook();
-                $addressbook->setPrincipalUri(Principal::PREFIX.$user->getUsername())
+                $addressbook->setPrincipalUri($user->getPrincipalUri())
                          ->setUri('default') // No risk of collision since unicity is guaranteed by the new user principal
                          ->setDisplayName($trans->trans('default.addressbook.title'))
                          ->setDescription($trans->trans('default.addressbook.description', ['user' => $displayName]));
@@ -125,21 +126,16 @@ class UserController extends AbstractController
     }
 
     #[Route('/delete/{userId}', name: 'delete', methods: ['POST'])]
-    public function userDelete(ManagerRegistry $doctrine, Request $request, int $userId, TranslatorInterface $trans): Response
+    public function userDelete(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, TranslatorInterface $trans): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
         $entityManager = $doctrine->getManager();
         $entityManager->remove($user);
 
-        $principal = $doctrine->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.$user->getUsername());
+        $principal = $doctrine->getRepository(Principal::class)->findOneByUri($user->getPrincipalUri());
         $principalProxyRead = $doctrine->getRepository(Principal::class)->findOneByUri($principal->getUri().Principal::READ_PROXY_SUFFIX);
         $principalProxyWrite = $doctrine->getRepository(Principal::class)->findOneByUri($principal->getUri().Principal::WRITE_PROXY_SUFFIX);
 
@@ -153,7 +149,7 @@ class UserController extends AbstractController
             $entityManager->remove($principalProxyWrite);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         // Remove calendars and addressbooks
         $calendars = $doctrine->getRepository(CalendarInstance::class)->findByPrincipalUri($principalUri);
@@ -203,14 +199,9 @@ class UserController extends AbstractController
     }
 
     #[Route('/delegates/{userId}', name: 'delegates')]
-    public function userDelegates(ManagerRegistry $doctrine, int $userId): Response
+    public function userDelegates(ManagerRegistry $doctrine, #[MapEntity(id: 'userId')] User $user, int $userId): Response
     {
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         $principal = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri);
 
@@ -231,18 +222,13 @@ class UserController extends AbstractController
     }
 
     #[Route('/delegation/{userId}/{toggle}', name: 'delegation_toggle', requirements: ['toggle' => '(on|off)'], methods: ['POST'])]
-    public function userToggleDelegation(ManagerRegistry $doctrine, Request $request, int $userId, string $toggle): Response
+    public function userToggleDelegation(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, string $toggle): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         $principal = $doctrine->getRepository(Principal::class)->findOneByUri($principalUri);
 
@@ -279,7 +265,7 @@ class UserController extends AbstractController
     }
 
     #[Route('/delegates/{userId}/add', name: 'delegate_add', methods: ['POST'])]
-    public function userDelegateAdd(ManagerRegistry $doctrine, Request $request, int $userId): Response
+    public function userDelegateAdd(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
@@ -289,12 +275,7 @@ class UserController extends AbstractController
             throw new BadRequestHttpException();
         }
 
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
-
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         $newMemberToAdd = $doctrine->getRepository(Principal::class)->findOneById($request->request->get('principalId'));
 
@@ -328,19 +309,16 @@ class UserController extends AbstractController
     }
 
     #[Route('/delegates/{userId}/remove/{principalProxyId}/{delegateId}', name: 'delegate_remove', requirements: ['principalProxyId' => "\d+", 'delegateId' => "\d+"], methods: ['POST'])]
-    public function userDelegateRemove(ManagerRegistry $doctrine, Request $request, int $userId, int $principalProxyId, int $delegateId): Response
+    public function userDelegateRemove(ManagerRegistry $doctrine, Request $request, #[MapEntity(id: 'userId')] User $user, int $userId, int $principalProxyId, int $delegateId): Response
     {
         if (!$this->isCsrfTokenValid('admin_action', $request->getPayload()->getString('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $user = $doctrine->getRepository(User::class)->findOneById($userId);
-        if (!$user) {
-            throw $this->createNotFoundException('User not found');
-        }
+        $principalUri = $user->getPrincipalUri();
 
         $principalProxy = $doctrine->getRepository(Principal::class)->findOneById($principalProxyId);
-        if (!$principalProxy) {
+        if (!$principalProxy || !in_array($principalProxy->getUri(), [$principalUri.Principal::READ_PROXY_SUFFIX, $principalUri.Principal::WRITE_PROXY_SUFFIX], true)) {
             throw $this->createNotFoundException('Principal linked to this calendar not found');
         }
 

--- a/src/Controller/Api/ApiController.php
+++ b/src/Controller/Api/ApiController.php
@@ -6,7 +6,6 @@ use App\Entity\Calendar;
 use App\Entity\CalendarInstance;
 use App\Entity\CalendarSubscription;
 use App\Entity\Principal;
-use App\Entity\SchedulingObject;
 use App\Entity\User;
 use Doctrine\Persistence\ManagerRegistry;
 use Sabre\DAV\Sharing\Plugin as SharingPlugin;
@@ -48,6 +47,17 @@ class ApiController extends AbstractController
     private function resolveUser(ManagerRegistry $doctrine, int $userId): ?User
     {
         return $doctrine->getRepository(User::class)->findOneById($userId);
+    }
+
+    /**
+     * Resolves a calendar instance that belongs to the principal *as an owner*
+     * (a calendar merely shared with the principal does not qualify).
+     */
+    private function resolveOwnerInstance(ManagerRegistry $doctrine, int $calendarInstanceId, string $principalUri): ?CalendarInstance
+    {
+        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneForPrincipal($calendarInstanceId, $principalUri);
+
+        return $instance && !$instance->isShared() ? $instance : null;
     }
 
     /**
@@ -111,7 +121,7 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principal = $doctrine->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.$user->getUsername());
+        $principal = $doctrine->getRepository(Principal::class)->findOneByUri($user->getPrincipalUri());
 
         if (!$principal) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
@@ -151,7 +161,7 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
@@ -185,18 +195,14 @@ class ApiController extends AbstractController
 
         $subscriptions = [];
         foreach ($allSubscriptions as $subscription) {
-            $objectCounts = $doctrine->getRepository(CalendarInstance::class)->getObjectCountsByComponentType($subscription->getCalendar()->getId());
-            $eventsCount = $subscription->getCalendar()->isComponentEnabled(Calendar::COMPONENT_EVENTS) ? $objectCounts['events'] : null;
-            $notesCount = $subscription->getCalendar()->isComponentEnabled(Calendar::COMPONENT_NOTES) ? $objectCounts['notes'] : null;
-            $tasksCount = $subscription->getCalendar()->isComponentEnabled(Calendar::COMPONENT_TODOS) ? $objectCounts['tasks'] : null;
-
+            // A subscription is a remote feed: it has no local calendar, hence no object counts
             $subscriptions[] = [
                 'id' => $subscription->getId(),
                 'uri' => $subscription->getUri(),
                 'displayname' => $subscription->getDisplayName(),
-                'events' => $eventsCount,
-                'notes' => $notesCount,
-                'tasks' => $tasksCount,
+                'events' => null,
+                'notes' => null,
+                'tasks' => null,
             ];
         }
 
@@ -230,7 +236,7 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
@@ -288,7 +294,7 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
@@ -391,24 +397,16 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $ownerInstance = $doctrine->getRepository(CalendarInstance::class)->findOneBy([
-            'id' => $calendar_id,
-            'principalUri' => $principalUri,
-        ]);
-
-        if (!$ownerInstance) {
-            return $this->json(['status' => 'error', 'message' => 'Invalid Calendar ID', 'timestamp' => $this->getTimestamp()], 400);
-        }
-
-        $calendarInstance = $doctrine->getRepository(CalendarInstance::class)->findOneById($calendar_id);
+        // Only the owner of a calendar can edit it (a sharee's instance is not theirs to change)
+        $calendarInstance = $this->resolveOwnerInstance($doctrine, $calendar_id, $principalUri);
         if (!$calendarInstance) {
-            return $this->json(['status' => 'error', 'message' => 'Calendar Instance Not Found', 'timestamp' => $this->getTimestamp()], 404);
+            return $this->json(['status' => 'error', 'message' => 'Invalid Calendar ID', 'timestamp' => $this->getTimestamp()], 400);
         }
 
         // Parse JSON body
@@ -478,16 +476,13 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneBy([
-            'id' => $calendar_id,
-            'principalUri' => $principalUri,
-        ]);
+        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneForPrincipal($calendar_id, $principalUri);
 
         if (!$instance) {
             return $this->json(['status' => 'error', 'message' => 'Invalid Instance Not Found', 'timestamp' => $this->getTimestamp()], 400);
@@ -495,13 +490,17 @@ class ApiController extends AbstractController
 
         try {
             $entityManager = $doctrine->getManager();
-            $calendarsSubscriptions = $doctrine->getRepository(CalendarSubscription::class)->findByPrincipalUri($instance->getPrincipalUri());
-            $schedulingObjects = $doctrine->getRepository(SchedulingObject::class)->findByPrincipalUri($instance->getPrincipalUri());
 
-            // Remove calendar objects
-            foreach ($calendarsSubscriptions ?? [] as $subscription) {
-                $entityManager->remove($subscription);
+            // A calendar shared *with* this user is not theirs to delete: only drop their access to it
+            if ($instance->isShared()) {
+                $entityManager->remove($instance);
+                $entityManager->flush();
+
+                return $this->json(['status' => 'success', 'timestamp' => $this->getTimestamp()], 200);
             }
+
+            // Scheduling objects attached to the calendar objects of this calendar only
+            $schedulingObjects = $doctrine->getRepository(CalendarInstance::class)->findAllSchedulingObjectsForCalendar($instance->getId(), $principalUri);
             foreach ($schedulingObjects ?? [] as $object) {
                 $entityManager->remove($object);
             }
@@ -547,16 +546,13 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $ownerInstance = $doctrine->getRepository(CalendarInstance::class)->findOneBy([
-            'id' => $calendar_id,
-            'principalUri' => $principalUri,
-        ]);
+        $ownerInstance = $this->resolveOwnerInstance($doctrine, $calendar_id, $principalUri);
 
         if (!$ownerInstance) {
             return $this->json(['status' => 'error', 'message' => 'Invalid Calendar ID/Username', 'timestamp' => $this->getTimestamp()], 400);
@@ -570,7 +566,8 @@ class ApiController extends AbstractController
             $principalId = $doctrine->getRepository(Principal::class)->findOneByUri($instance[0]['principalUri']);
 
             $instanceUsername = mb_substr($instance[0]['principalUri'], strlen(Principal::PREFIX));
-            $instanceUserId = $doctrine->getRepository(User::class)->findOneByUsername($instanceUsername)->getId();
+            // A sharee principal may have no user row (deleted user, external principal)
+            $instanceUserId = $doctrine->getRepository(User::class)->findOneByUsername($instanceUsername)?->getId();
 
             $calendars[] = [
                 'username' => $instanceUsername,
@@ -608,18 +605,15 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $ownerInstance = $doctrine->getRepository(CalendarInstance::class)->findOneBy([
-            'id' => $calendar_id,
-            'principalUri' => $principalUri,
-        ]);
+        $instance = $this->resolveOwnerInstance($doctrine, $calendar_id, $principalUri);
 
-        if (!$ownerInstance) {
+        if (!$instance) {
             return $this->json(['status' => 'error', 'message' => 'Invalid Calendar ID and User ID', 'timestamp' => $this->getTimestamp()], 400);
         }
 
@@ -635,11 +629,13 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'Invalid Sharee ID/Write Access Value', 'timestamp' => $this->getTimestamp()], 400);
         }
 
-        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($calendar_id);
         $newShareeToAdd = $doctrine->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.$shareeUsername);
 
-        if (!$instance || !$newShareeToAdd) {
+        if (!$newShareeToAdd) {
             return $this->json(['status' => 'error', 'message' => 'Calendar Instance/User Not Found', 'timestamp' => $this->getTimestamp()], 404);
+        }
+        if ($newShareeToAdd->getUri() === $principalUri) {
+            return $this->json(['status' => 'error', 'message' => 'A Calendar Cannot Be Shared With Its Owner', 'timestamp' => $this->getTimestamp()], 400);
         }
 
         $existingSharedInstance = $doctrine->getRepository(CalendarInstance::class)->findSharedInstanceOfInstanceFor($instance->getCalendar()->getId(), $newShareeToAdd->getUri());
@@ -687,18 +683,15 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $principalUri = Principal::PREFIX.$user->getUsername();
+        $principalUri = $user->getPrincipalUri();
 
         if (!$doctrine->getRepository(Principal::class)->findOneByUri($principalUri)) {
             return $this->json(['status' => 'error', 'message' => 'Principal Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 
-        $ownerInstance = $doctrine->getRepository(CalendarInstance::class)->findOneBy([
-            'id' => $calendar_id,
-            'principalUri' => $principalUri,
-        ]);
+        $instance = $this->resolveOwnerInstance($doctrine, $calendar_id, $principalUri);
 
-        if (!$ownerInstance) {
+        if (!$instance) {
             return $this->json(['status' => 'error', 'message' => 'Invalid Calendar ID', 'timestamp' => $this->getTimestamp()], 400);
         }
 
@@ -713,10 +706,9 @@ class ApiController extends AbstractController
             return $this->json(['status' => 'error', 'message' => 'Invalid Username', 'timestamp' => $this->getTimestamp()], 400);
         }
 
-        $instance = $doctrine->getRepository(CalendarInstance::class)->findOneById($calendar_id);
         $shareeToRemove = $doctrine->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.$shareeUsername);
 
-        if (!$instance || !$shareeToRemove) {
+        if (!$shareeToRemove) {
             return $this->json(['status' => 'error', 'message' => 'Calendar Instance/User Not Found', 'timestamp' => $this->getTimestamp()], 404);
         }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -30,6 +30,14 @@ class User
         return $this->id;
     }
 
+    /**
+     * A user's principal is always `principals/<username>`.
+     */
+    public function getPrincipalUri(): string
+    {
+        return Principal::PREFIX.$this->username;
+    }
+
     public function getUsername(): ?string
     {
         return $this->username;

--- a/src/Form/AddressBookType.php
+++ b/src/Form/AddressBookType.php
@@ -5,7 +5,6 @@ namespace App\Form;
 use App\Entity\AddressBook;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -17,9 +16,6 @@ class AddressBookType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('principalUri', HiddenType::class, [
-                'required' => true,
-            ])
             ->add('uri', TextType::class, [
                 'label' => 'form.uri',
                 'disabled' => !$options['new'],

--- a/src/Form/CalendarInstanceType.php
+++ b/src/Form/CalendarInstanceType.php
@@ -6,7 +6,6 @@ use App\Entity\CalendarInstance;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -18,9 +17,6 @@ class CalendarInstanceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('principalUri', HiddenType::class, [
-                'required' => true,
-            ])
             ->add('uri', TextType::class, [
                 'label' => 'form.uri',
                 'disabled' => !$options['new'],

--- a/src/Plugins/PublicAwareDAVACLPlugin.php
+++ b/src/Plugins/PublicAwareDAVACLPlugin.php
@@ -28,11 +28,20 @@ class PublicAwareDAVACLPlugin extends \Sabre\DAVACL\Plugin
     /**
      * We override this method so that public objects can be seen correctly in the browser,
      * with the assets (css, images).
+     *
+     * The browser plugin always builds asset URLs against the server base URI
+     * (see \Sabre\DAV\Browser\Plugin::getAssetUrl), i.e. `GET /dav/?sabreAction=asset&assetName=...`.
+     * The root collection is only readable by authenticated principals, so we skip the ACL
+     * check for that exact case only. Every other method or path (e.g. a GET or PUT on a
+     * calendar object with `?sabreAction=asset` appended) must go through the regular checks:
+     * this method is the only place where `{DAV:}read` and `{DAV:}write-content` are enforced.
      */
     public function beforeMethod(RequestInterface $request, ResponseInterface $response)
     {
         $params = $request->getQueryParameters();
-        if (isset($params['sabreAction']) && 'asset' === $params['sabreAction']) {
+        if (isset($params['sabreAction']) && 'asset' === $params['sabreAction']
+            && in_array($request->getMethod(), ['GET', 'HEAD'], true)
+            && '' === $request->getPath()) {
             return;
         }
 

--- a/src/Repository/CalendarInstanceRepository.php
+++ b/src/Repository/CalendarInstanceRepository.php
@@ -63,6 +63,30 @@ class CalendarInstanceRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * Returns the instance only if it belongs to the given principal (owner or sharee).
+     */
+    public function findOneForPrincipal(int $id, string $principalUri): ?CalendarInstance
+    {
+        return $this->findOneBy(['id' => $id, 'principalUri' => $principalUri]);
+    }
+
+    /**
+     * Returns the principal's *owner* instance of the given calendar, if any.
+     */
+    public function findOwnerInstanceOfCalendarForPrincipal(int $calendarId, string $principalUri): ?CalendarInstance
+    {
+        return $this->createQueryBuilder('c')
+            ->where('c.calendar = :id')
+            ->setParameter('id', $calendarId)
+            ->andWhere('c.principalUri = :principalUri')
+            ->setParameter('principalUri', $principalUri)
+            ->andWhere('c.access IN (:ownerAccess)')
+            ->setParameter('ownerAccess', CalendarInstance::getOwnerAccesses())
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function hasDifferentOwner(int $calendarId, string $principalUri): bool
     {
         return $this->createQueryBuilder('c')
@@ -77,10 +101,10 @@ class CalendarInstanceRepository extends ServiceEntityRepository
             ->getSingleScalarResult() > 0;
     }
 
-
     public function findAllSchedulingObjectsForCalendar(int $calendarInstanceId, string $principalUri): array
     {
         $objectRepository = $this->getEntityManager()->getRepository(SchedulingObject::class);
+
         return $objectRepository->createQueryBuilder('s')
             ->innerJoin(CalendarObject::class, 'c', \Doctrine\ORM\Query\Expr\Join::WITH, 'c.uri = s.uri')
             ->innerJoin(CalendarInstance::class, 'ci', \Doctrine\ORM\Query\Expr\Join::WITH, 'ci.calendar = c.calendar')

--- a/src/Services/AbstractAuth.php
+++ b/src/Services/AbstractAuth.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services;
+
+use Sabre\DAV\Auth\Backend\AbstractBasic;
+
+/**
+ * Common base for the HTTP Basic authentication backends (internal, IMAP, LDAP).
+ *
+ * It rejects empty usernames and passwords before any backend is contacted.
+ * sabre/dav hands us `['user', '']` for an `Authorization: Basic base64("user:")` header,
+ * and an empty password means an *unauthenticated bind* for LDAP servers, which Active
+ * Directory (and OpenLDAP with `allow bind_anon_cred`) answers with success, i.e. it
+ * would log the caller in as any user.
+ */
+abstract class AbstractAuth extends AbstractBasic
+{
+    /**
+     * @param string $username
+     * @param string $password
+     */
+    final protected function validateUserPass($username, $password): bool
+    {
+        if (!is_string($username) || !is_string($password) || '' === $username || '' === $password) {
+            return false;
+        }
+
+        return $this->checkCredentials($username, $password);
+    }
+
+    /**
+     * Validates a non-empty username and password against the backend.
+     */
+    abstract protected function checkCredentials(string $username, string $password): bool;
+}

--- a/src/Services/BasicAuth.php
+++ b/src/Services/BasicAuth.php
@@ -4,9 +4,8 @@ namespace App\Services;
 
 use App\Entity\User;
 use Doctrine\Persistence\ManagerRegistry;
-use Sabre\DAV\Auth\Backend\AbstractBasic;
 
-final class BasicAuth extends AbstractBasic
+final class BasicAuth extends AbstractAuth
 {
     /**
      * Utils class.
@@ -28,7 +27,7 @@ final class BasicAuth extends AbstractBasic
         $this->doctrine = $doctrine;
     }
 
-    protected function validateUserPass($username, $password): bool
+    protected function checkCredentials(string $username, string $password): bool
     {
         $user = $this->doctrine->getRepository(User::class)->findOneByUsername($username);
 

--- a/src/Services/IMAPAuth.php
+++ b/src/Services/IMAPAuth.php
@@ -4,11 +4,10 @@ namespace App\Services;
 
 use App\Entity\User;
 use Doctrine\Persistence\ManagerRegistry;
-use Sabre\DAV\Auth\Backend\AbstractBasic;
 use Webklex\PHPIMAP\Client;
 use Webklex\PHPIMAP\ClientManager;
 
-final class IMAPAuth extends AbstractBasic
+final class IMAPAuth extends AbstractAuth
 {
     /**
      * Doctrine registry.
@@ -150,7 +149,7 @@ final class IMAPAuth extends AbstractBasic
     /**
      * Validates a username and password by trying to authenticate against IMAP.
      */
-    protected function validateUserPass($username, $password): bool
+    protected function checkCredentials(string $username, string $password): bool
     {
         return $this->imapOpen($username, $password);
     }

--- a/src/Services/LDAPAuth.php
+++ b/src/Services/LDAPAuth.php
@@ -4,9 +4,8 @@ namespace App\Services;
 
 use App\Entity\User;
 use Doctrine\Persistence\ManagerRegistry;
-use Sabre\DAV\Auth\Backend\AbstractBasic;
 
-final class LDAPAuth extends AbstractBasic
+final class LDAPAuth extends AbstractAuth
 {
     /**
      * LDAP server uri.
@@ -222,11 +221,8 @@ final class LDAPAuth extends AbstractBasic
 
     /**
      * Validates a username and password by trying to authenticate against LDAP.
-     *
-     * @param string $username
-     * @param string $password
      */
-    protected function validateUserPass($username, $password): bool
+    protected function checkCredentials(string $username, string $password): bool
     {
         return $this->ldapOpen($username, $password);
     }

--- a/src/Services/Utils.php
+++ b/src/Services/Utils.php
@@ -61,14 +61,14 @@ final class Utils
 
         // Create principal, default calendar and addressbook
         $principal = new Principal();
-        $principal->setUri(Principal::PREFIX.$username)
+        $principal->setUri($user->getPrincipalUri())
                 ->setDisplayName($displayName)
                 ->setEmail($email)
                 ->setIsAdmin(false);
 
         $calendarInstance = new CalendarInstance();
         $calendar = new Calendar();
-        $calendarInstance->setPrincipalUri(Principal::PREFIX.$username)
+        $calendarInstance->setPrincipalUri($user->getPrincipalUri())
                 ->setUri('default') // No risk of collision since unicity is guaranteed by the new user principal
                 ->setDisplayName($this->trans->trans('default.calendar.title'))
                 ->setDescription($this->trans->trans('default.calendar.description', ['user' => $displayName]))
@@ -84,7 +84,7 @@ final class Utils
                         ->setIsMain(false);
 
         $addressbook = new AddressBook();
-        $addressbook->setPrincipalUri(Principal::PREFIX.$username)
+        $addressbook->setPrincipalUri($user->getPrincipalUri())
                 ->setUri('default') // No risk of collision since unicity is guaranteed by the new user principal
                 ->setDisplayName($this->trans->trans('default.addressbook.title'))
                 ->setDescription($this->trans->trans('default.addressbook.description', ['user' => $displayName]));

--- a/templates/_partials/delegate_row.html.twig
+++ b/templates/_partials/delegate_row.html.twig
@@ -21,6 +21,6 @@
     <p class="mb-1">{{ "users.username"|trans }} : <code>{{ delegate.username }}</code></p>
     <small>{{ "users.uri"|trans }} : <code>{{ delegate.uri }}</code></small>
     <div class="btn-group btn-group-sm mt-3 d-flex d-lg-none" role="group">
-        <a href="#" data-href="{{ path('user_delegate_remove',{userId: userId, principalProxyId: has_write ? principalProxyWrite.id : principalProxyRead.id, delegateId: delegate.id})}}" data-flavour="delegates" class="btn btn-outline-danger flex-fill flex-shrink-1 delete-modal"><span class="d-none d-sm-inline">⚠&nbsp;</span>{{ "remove"|trans }}</a>
+        <a href="#" data-bs-toggle="modal" data-bs-target="#deleteModal-delegates" data-href="{{ path('user_delegate_remove',{userId: userId, principalProxyId: has_write ? principalProxyWrite.id : principalProxyRead.id, delegateId: delegate.id})}}" data-flavour="delegates" class="btn btn-outline-danger flex-fill flex-shrink-1 delete-modal"><span class="d-none d-sm-inline">⚠&nbsp;</span>{{ "remove"|trans }}</a>
     </div>
 </div>

--- a/templates/_partials/delete_modal.html.twig
+++ b/templates/_partials/delete_modal.html.twig
@@ -10,7 +10,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ "cancel"|trans }}</button>
-        <a href="#" type="button" class="btn btn-primary" id="deleteModal-{{ flavour }}-cta">{{ "yes"|trans }}</a>
+        <button type="button" class="btn btn-primary" id="deleteModal-{{ flavour }}-cta">{{ "yes"|trans }}</button>
       </div>
     </div>
   </div>

--- a/templates/_partials/share_modal.html.twig
+++ b/templates/_partials/share_modal.html.twig
@@ -13,7 +13,7 @@
                     <span class="name"></span>
                     <span class="badge bg-info rounded-pill ms-2"></span>
                 </div>
-                <a href="#" class="btn btn-sm btn-danger revoke">{{ "revoke"|trans }}</a>
+                <button type="button" class="btn btn-sm btn-danger revoke">{{ "revoke"|trans }}</button>
             </div>
         </template>
         <span class="d-none" id="shareModal-none"><em>{{ "calendars.delegates.none"|trans }}</em></span>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
+        <meta name="csrf-token" content="{{ csrf_token('admin_action') }}">
         <title>{% block title %}Davis{% endblock %}</title>
         <script type="text/javascript" src="/js/color.mode.toggler.js"></script>
         <link rel="stylesheet" href="/css/bootstrap.min.css" />

--- a/templates/users/delegates.html.twig
+++ b/templates/users/delegates.html.twig
@@ -17,7 +17,10 @@
 {% if delegation %}
     <div class="alert alert-success d-flex justify-content-between mb-4 mt-2" role="alert">
       <div>{{ "delegates.enabled.text"|trans }}<br><small>{{ "delegates.disable.warning"|trans }}</small></div>
-      <a href="{{ path('user_delegation_toggle', {userId: userId, toggle: 'off'})}}" class="btn btn-sm my-auto btn-outline-danger">{{ "delegates.disable"|trans }}</a>
+      <form method="post" action="{{ path('user_delegation_toggle', {userId: userId, toggle: 'off'})}}" class="my-auto">
+        <input type="hidden" name="_token" value="{{ csrf_token('admin_action') }}">
+        <button type="submit" class="btn btn-sm btn-outline-danger">{{ "delegates.disable"|trans }}</button>
+      </form>
     </div>
     {% for delegate in principalProxyRead.delegees %}
         {% include '_partials/delegate_row.html.twig' with {has_write: false} %}
@@ -28,7 +31,11 @@
 
 {% else %}
     <div class="alert alert-warning d-flex justify-content-between mb-4 mt-2" role="alert">
-      {{ "delegates.disabled.text"|trans }}<a href="{{ path('user_delegation_toggle', {userId: userId, toggle: 'on'})}}" class="btn btn-sm my-auto btn-warning">{{ "delegates.enable"|trans }}</a>
+      {{ "delegates.disabled.text"|trans }}
+      <form method="post" action="{{ path('user_delegation_toggle', {userId: userId, toggle: 'on'})}}" class="my-auto">
+        <input type="hidden" name="_token" value="{{ csrf_token('admin_action') }}">
+        <button type="submit" class="btn btn-sm btn-warning">{{ "delegates.enable"|trans }}</button>
+      </form>
     </div>
 {% endif %}
 

--- a/tests/Functional/AdminPostTrait.php
+++ b/tests/Functional/AdminPostTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * State-changing admin actions are POST requests that must carry the CSRF token
+ * published in the layout's <meta name="csrf-token"> tag.
+ */
+trait AdminPostTrait
+{
+    private function getAdminCsrfToken(KernelBrowser $client): string
+    {
+        $crawler = $client->request('GET', '/dashboard');
+        $this->assertResponseIsSuccessful();
+
+        return $crawler->filter('meta[name="csrf-token"]')->attr('content');
+    }
+
+    /**
+     * Fetches a valid CSRF token and POSTs it, together with $params, to $url.
+     */
+    private function postAdmin(KernelBrowser $client, string $url, array $params = []): Crawler
+    {
+        $token = $this->getAdminCsrfToken($client);
+
+        return $client->request('POST', $url, array_merge(['_token' => $token], $params));
+    }
+}

--- a/tests/Functional/Controllers/AddressBookControllerTest.php
+++ b/tests/Functional/Controllers/AddressBookControllerTest.php
@@ -137,4 +137,50 @@ class AddressBookControllerTest extends WebTestCase
 
         $this->assertNotNull($addressbookRepository->find($addressbook->getId()));
     }
+
+    public function testAddressBookActionsOnAnotherUsersBookAre404(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $otherId = $this->getUserId($client, 'test_user2');
+
+        $addressbookRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(AddressBook::class);
+        $addressbook = $addressbookRepository->findOneByDisplayName('default.addressbook.title');
+
+        $client->request('GET', '/addressbooks/'.$otherId.'/edit/'.$addressbook->getId());
+        $this->assertResponseStatusCodeSame(404);
+
+        $this->postAdmin($client, '/addressbooks/'.$otherId.'/delete/'.$addressbook->getId());
+        $this->assertResponseStatusCodeSame(404);
+
+        $this->assertNotNull($addressbookRepository->find($addressbook->getId()));
+    }
+
+    public function testAddressBookNewIgnoresASubmittedOwner(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+
+        $crawler = $client->request('GET', '/addressbooks/'.$userId.'/new');
+        $this->assertSelectorNotExists('input[name="address_book[principalUri]"]');
+
+        $form = $crawler->selectButton('address_book_save')->form();
+        $values = $form->getPhpValues();
+        $values['address_book']['uri'] = 'hijack';
+        $values['address_book']['displayName'] = 'Hijack';
+        $values['address_book']['principalUri'] = 'principals/test_user2';
+
+        $client->request($form->getMethod(), $form->getUri(), $values);
+
+        $this->assertResponseIsSuccessful();
+        $addressbookRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(AddressBook::class);
+        $this->assertNull($addressbookRepository->findOneBy(['uri' => 'hijack']));
+    }
 }

--- a/tests/Functional/Controllers/AddressBookControllerTest.php
+++ b/tests/Functional/Controllers/AddressBookControllerTest.php
@@ -9,6 +9,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class AddressBookControllerTest extends WebTestCase
 {
+    use AdminPostTrait;
+
     private function getUserId($client, string $username): int
     {
         $userRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(User::class);
@@ -107,11 +109,32 @@ class AddressBookControllerTest extends WebTestCase
         $addressbookRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(AddressBook::class);
         $addressbook = $addressbookRepository->findOneByDisplayName('default.addressbook.title');
 
-        $client->request('GET', '/addressbooks/'.$userId.'/delete/'.$addressbook->getId());
+        $this->postAdmin($client, '/addressbooks/'.$userId.'/delete/'.$addressbook->getId());
 
         $this->assertResponseRedirects('/addressbooks/'.$userId);
         $client->followRedirect();
 
         $this->assertSelectorTextNotContains('h5', 'default.addressbook.title');
+    }
+
+    public function testAddressBookDeleteRejectsGetAndInvalidCsrfToken(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+
+        $addressbookRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(AddressBook::class);
+        $addressbook = $addressbookRepository->findOneByDisplayName('default.addressbook.title');
+
+        $client->request('GET', '/addressbooks/'.$userId.'/delete/'.$addressbook->getId());
+        $this->assertResponseStatusCodeSame(405);
+
+        $client->request('POST', '/addressbooks/'.$userId.'/delete/'.$addressbook->getId(), ['_token' => 'not-the-token']);
+        $this->assertResponseStatusCodeSame(403);
+
+        $this->assertNotNull($addressbookRepository->find($addressbook->getId()));
     }
 }

--- a/tests/Functional/Controllers/ApiControllerTest.php
+++ b/tests/Functional/Controllers/ApiControllerTest.php
@@ -2,6 +2,13 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\Calendar;
+use App\Entity\CalendarInstance;
+use App\Entity\CalendarObject;
+use App\Entity\CalendarSubscription;
+use App\Entity\Principal;
+use App\Entity\SchedulingObject;
+use Sabre\DAV\Sharing\Plugin as SharingPlugin;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class ApiControllerTest extends WebTestCase
@@ -582,5 +589,148 @@ class ApiControllerTest extends WebTestCase
         $data = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals('success', $data['status']);
         $this->assertEmpty($data['data']);
+    }
+
+    private function apiHeaders(): array
+    {
+        return [
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_X_DAVIS_API_TOKEN' => $_ENV['API_KEY'],
+            'CONTENT_TYPE' => 'application/json',
+        ];
+    }
+
+    /**
+     * Shares test_user's default calendar with test_user2 (directly in the database) and
+     * adds one event to it. Returns [ownerInstanceId, sharedInstanceId, calendarId].
+     */
+    private function seedSharedCalendar(): array
+    {
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $ownerInstance = $em->getRepository(CalendarInstance::class)->findOneBy(['principalUri' => Principal::PREFIX.'test_user', 'uri' => 'default']);
+        $calendar = $ownerInstance->getCalendar();
+
+        $object = (new CalendarObject())->setCalendar($calendar)->setUri('event.ics')->setCalendarData("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")
+            ->setEtag('e')->setSize(30)->setComponentType('VEVENT')->setUid('event-1')->setLastModified(time());
+        $em->persist($object);
+        $shared = (new CalendarInstance())->setCalendar($calendar)->setPrincipalUri(Principal::PREFIX.'test_user2')->setUri('shared-uuid')
+            ->setAccess(SharingPlugin::ACCESS_READWRITE)->setDisplayName('Shared with me');
+        $em->persist($shared);
+        $em->flush();
+
+        $ids = [$ownerInstance->getId(), $shared->getId(), $calendar->getId()];
+        $em->clear();
+
+        return $ids;
+    }
+
+    public function testDeleteUserCalendarKeepsSubscriptionsAndUnrelatedSchedulingObjects(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $subscription = (new CalendarSubscription())->setPrincipalUri(Principal::PREFIX.'test_user')->setUri('holidays')
+            ->setSource('https://example.org/holidays.ics')->setDisplayName('Holidays')->setCalendarOrder(0)->setLastModified(time());
+        $em->persist($subscription);
+        $inboxItem = (new SchedulingObject())->setPrincipalUri(Principal::PREFIX.'test_user')->setUri('invite.ics')
+            ->setCalendarData("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")->setEtag('e')->setSize(30)->setLastModified(time());
+        $em->persist($inboxItem);
+        $em->flush();
+        $em->clear();
+
+        $userId = $this->getUserId($client, 0);
+        $calendarId = $this->getCalendarId($client, $userId, true);
+
+        $client->request('DELETE', '/api/v1/calendars/'.$userId.'/'.$calendarId, [], [], $this->apiHeaders());
+        $this->assertResponseIsSuccessful();
+
+        $em->clear();
+        $this->assertSame(1, $em->getRepository(CalendarSubscription::class)->count(['principalUri' => Principal::PREFIX.'test_user']), 'Subscriptions must survive a calendar deletion');
+        $this->assertSame(1, $em->getRepository(SchedulingObject::class)->count(['principalUri' => Principal::PREFIX.'test_user']), 'Unrelated inbox items must survive a calendar deletion');
+    }
+
+    public function testDeleteSharedCalendarInstanceOnlyRemovesTheShare(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        [$ownerInstanceId, $sharedId, $calendarId] = $this->seedSharedCalendar();
+
+        $shareeUserId = $this->getUserId($client, 1);
+
+        $client->request('DELETE', '/api/v1/calendars/'.$shareeUserId.'/'.$sharedId, [], [], $this->apiHeaders());
+        $this->assertResponseIsSuccessful();
+        $this->assertEquals('success', json_decode($client->getResponse()->getContent(), true)['status']);
+
+        $em->clear();
+        $this->assertNull($em->getRepository(CalendarInstance::class)->find($sharedId), 'The share is gone');
+        $this->assertNotNull($em->getRepository(CalendarInstance::class)->find($ownerInstanceId), 'The owner still has the calendar');
+        $this->assertNotNull($em->getRepository(Calendar::class)->find($calendarId), 'The calendar row still exists');
+        $this->assertSame(1, $em->getRepository(CalendarObject::class)->count(['calendar' => $calendarId]), 'The owner\'s events are intact');
+    }
+
+    public function testSharedCalendarInstanceCannotBeEditedOrReSharedBySharee(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        [, $sharedId, $calendarId] = $this->seedSharedCalendar();
+
+        $shareeUserId = $this->getUserId($client, 1);
+
+        $client->request('PUT', '/api/v1/calendars/'.$shareeUserId.'/'.$sharedId, [], [], $this->apiHeaders(), json_encode(['name' => 'Hijacked', 'events_support' => false, 'tasks_support' => true]));
+        $this->assertResponseStatusCodeSame(400);
+
+        $client->request('GET', '/api/v1/calendars/'.$shareeUserId.'/shares/'.$sharedId, [], [], $this->apiHeaders());
+        $this->assertResponseStatusCodeSame(400);
+
+        $client->request('POST', '/api/v1/calendars/'.$shareeUserId.'/share/'.$sharedId.'/add', [], [], $this->apiHeaders(), json_encode(['username' => 'test_user2', 'write_access' => true]));
+        $this->assertResponseStatusCodeSame(400);
+
+        $client->request('POST', '/api/v1/calendars/'.$shareeUserId.'/share/'.$sharedId.'/remove', [], [], $this->apiHeaders(), json_encode(['username' => 'test_user2']));
+        $this->assertResponseStatusCodeSame(400);
+
+        $em->clear();
+        $this->assertSame('VEVENT', $em->getRepository(Calendar::class)->find($calendarId)->getComponents(), 'Components of the shared calendar are unchanged');
+        $this->assertNotNull($em->getRepository(CalendarInstance::class)->find($sharedId), 'The share still exists');
+    }
+
+    public function testShareCalendarWithItsOwnerIsRejected(): void
+    {
+        $client = static::createClient();
+        $userId = $this->getUserId($client, 0);
+        $calendarId = $this->getCalendarId($client, $userId, true);
+
+        $client->request('POST', '/api/v1/calendars/'.$userId.'/share/'.$calendarId.'/add', [], [], $this->apiHeaders(), json_encode(['username' => 'test_user', 'write_access' => true]));
+        $this->assertResponseStatusCodeSame(400);
+
+        $client->request('GET', '/api/v1/calendars/'.$userId.'/shares/'.$calendarId, [], [], $this->apiHeaders());
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([], json_decode($client->getResponse()->getContent(), true)['data']);
+    }
+
+    public function testSharesListToleratesAPrincipalWithoutUser(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        // A principal that has no matching row in `users` (e.g. a deleted user)
+        $ghost = (new Principal())->setUri(Principal::PREFIX.'ghost')->setEmail('ghost@test.com')->setDisplayName('Ghost')->setIsAdmin(false);
+        $em->persist($ghost);
+        $ownerInstance = $em->getRepository(CalendarInstance::class)->findOneBy(['principalUri' => Principal::PREFIX.'test_user', 'uri' => 'default']);
+        $shared = (new CalendarInstance())->setCalendar($ownerInstance->getCalendar())->setPrincipalUri(Principal::PREFIX.'ghost')->setUri('ghost-uuid')
+            ->setAccess(SharingPlugin::ACCESS_READ)->setDisplayName('x');
+        $em->persist($shared);
+        $em->flush();
+        $ownerInstanceId = $ownerInstance->getId();
+        $em->clear();
+
+        $userId = $this->getUserId($client, 0);
+        $client->request('GET', '/api/v1/calendars/'.$userId.'/shares/'.$ownerInstanceId, [], [], $this->apiHeaders());
+        $this->assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(1, $data['data']);
+        $this->assertSame('ghost', $data['data'][0]['username']);
+        $this->assertNull($data['data'][0]['user_id']);
     }
 }

--- a/tests/Functional/Controllers/CalendarControllerTest.php
+++ b/tests/Functional/Controllers/CalendarControllerTest.php
@@ -2,10 +2,14 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\Calendar;
+use App\Entity\CalendarInstance;
+use App\Entity\CalendarObject;
 use App\Entity\Principal;
 use App\Entity\User;
 use App\Repository\CalendarInstanceRepository;
 use App\Security\AdminUser;
+use Sabre\DAV\Sharing\Plugin as SharingPlugin;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class CalendarControllerTest extends WebTestCase
@@ -187,5 +191,126 @@ class CalendarControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
 
         $this->assertNotNull($calendarRepository->find($calendar->getId()));
+    }
+
+    private function loggedInClient(): \Symfony\Bundle\FrameworkBundle\KernelBrowser
+    {
+        $client = static::createClient();
+        $client->loginUser(new AdminUser('admin', 'test'));
+
+        return $client;
+    }
+
+    public function testCalendarActionsOnAnotherUsersCalendarAre404(): void
+    {
+        $client = $this->loggedInClient();
+
+        $ownerId = $this->getUserId($client, 'test_user');
+        $otherId = $this->getUserId($client, 'test_user2');
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
+        $sharee = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.'test_user');
+
+        $client->request('GET', '/calendars/'.$otherId.'/edit/'.$calendar->getId());
+        $this->assertResponseStatusCodeSame(404);
+
+        $client->request('GET', '/calendars/'.$otherId.'/shares/'.$calendar->getCalendar()->getId());
+        $this->assertResponseStatusCodeSame(404);
+
+        $this->postAdmin($client, '/calendars/'.$otherId.'/share/'.$calendar->getId(), ['principalId' => $sharee->getId(), 'write' => 'false']);
+        $this->assertResponseStatusCodeSame(404);
+
+        $this->postAdmin($client, '/calendars/'.$otherId.'/revoke/'.$calendar->getId());
+        $this->assertResponseStatusCodeSame(404);
+
+        $this->postAdmin($client, '/calendars/'.$otherId.'/delete/'.$calendar->getId());
+        $this->assertResponseStatusCodeSame(404);
+
+        $this->assertNotNull($calendarRepository->find($calendar->getId()), 'The owner\'s calendar must be untouched');
+        $this->assertSame(0, $calendarRepository->count(['principalUri' => Principal::PREFIX.'test_user2', 'calendar' => $calendar->getCalendar()]));
+        unset($ownerId);
+    }
+
+    public function testCalendarCannotBeSharedWithItsOwner(): void
+    {
+        $client = $this->loggedInClient();
+
+        $userId = $this->getUserId($client, 'test_user');
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
+        $owner = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.'test_user');
+
+        $this->postAdmin($client, '/calendars/'.$userId.'/share/'.$calendar->getId(), ['principalId' => $owner->getId(), 'write' => 'true']);
+        $this->assertResponseStatusCodeSame(400);
+
+        $this->assertSame(1, $calendarRepository->count(['calendar' => $calendar->getCalendar()]));
+    }
+
+    public function testDeletingASharedInstanceOnlyRevokesTheShare(): void
+    {
+        $client = $this->loggedInClient();
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $ownerInstance = $em->getRepository(CalendarInstance::class)->findOneBy(['principalUri' => Principal::PREFIX.'test_user', 'uri' => 'default']);
+        $calendar = $ownerInstance->getCalendar();
+
+        $object = (new CalendarObject())->setCalendar($calendar)->setUri('event.ics')->setCalendarData('BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n')
+            ->setEtag('e')->setSize(30)->setComponentType('VEVENT')->setUid('event-1')->setLastModified(time());
+        $em->persist($object);
+        $shared = (new CalendarInstance())->setCalendar($calendar)->setPrincipalUri(Principal::PREFIX.'test_user2')->setUri('shared-uuid')
+            ->setAccess(SharingPlugin::ACCESS_READWRITE)->setDisplayName('Shared with me');
+        $em->persist($shared);
+        $em->flush();
+        $sharedId = $shared->getId();
+        $ownerInstanceId = $ownerInstance->getId();
+        $calendarId = $calendar->getId();
+        $em->clear();
+
+        $shareeUserId = $this->getUserId($client, 'test_user2');
+        $this->postAdmin($client, '/calendars/'.$shareeUserId.'/delete/'.$sharedId);
+        $this->assertResponseRedirects('/calendars/'.$shareeUserId);
+
+        $em->clear();
+        $this->assertNull($em->getRepository(CalendarInstance::class)->find($sharedId), 'The share is gone');
+        $this->assertNotNull($em->getRepository(CalendarInstance::class)->find($ownerInstanceId), 'The owner still has the calendar');
+        $this->assertNotNull($em->getRepository(Calendar::class)->find($calendarId), 'The calendar row still exists');
+        $this->assertSame(1, $em->getRepository(CalendarObject::class)->count(['calendar' => $calendarId]), 'The owner\'s events are intact');
+    }
+
+    public function testRevokingAnOwnerInstanceIsRejected(): void
+    {
+        $client = $this->loggedInClient();
+
+        $userId = $this->getUserId($client, 'test_user');
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
+
+        $this->postAdmin($client, '/calendars/'.$userId.'/revoke/'.$calendar->getId());
+        $this->assertResponseStatusCodeSame(400);
+
+        $this->assertNotNull($calendarRepository->find($calendar->getId()));
+    }
+
+    public function testCalendarNewIgnoresASubmittedOwner(): void
+    {
+        $client = $this->loggedInClient();
+
+        $userId = $this->getUserId($client, 'test_user');
+
+        $crawler = $client->request('GET', '/calendars/'.$userId.'/new');
+        $this->assertSelectorNotExists('input[name="calendar_instance[principalUri]"]');
+
+        $form = $crawler->selectButton('calendar_instance_save')->form();
+        $values = $form->getPhpValues();
+        $values['calendar_instance']['uri'] = 'hijack';
+        $values['calendar_instance']['displayName'] = 'Hijack';
+        $values['calendar_instance']['principalUri'] = Principal::PREFIX.'test_user2';
+
+        $client->request($form->getMethod(), $form->getUri(), $values);
+
+        // Extra fields make the form invalid: re-rendered, nothing persisted
+        $this->assertResponseIsSuccessful();
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $this->assertNull($calendarRepository->findOneBy(['uri' => 'hijack']));
     }
 }

--- a/tests/Functional/Controllers/CalendarControllerTest.php
+++ b/tests/Functional/Controllers/CalendarControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\Principal;
 use App\Entity\User;
 use App\Repository\CalendarInstanceRepository;
 use App\Security\AdminUser;
@@ -9,6 +10,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class CalendarControllerTest extends WebTestCase
 {
+    use AdminPostTrait;
+
     private function getUserId($client, string $username): int
     {
         $userRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(User::class);
@@ -108,11 +111,81 @@ class CalendarControllerTest extends WebTestCase
         $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
         $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
 
-        $client->request('GET', '/calendars/'.$userId.'/delete/'.$calendar->getId());
+        $this->postAdmin($client, '/calendars/'.$userId.'/delete/'.$calendar->getId());
 
         $this->assertResponseRedirects('/calendars/'.$userId);
         $client->followRedirect();
 
         $this->assertSelectorTextNotContains('h5', 'default.calendar.title');
+    }
+
+    public function testCalendarShareAddAndRevoke(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
+        $sharee = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class)->findOneByUri(Principal::PREFIX.'test_user2');
+
+        $this->postAdmin($client, '/calendars/'.$userId.'/share/'.$calendar->getId(), ['principalId' => $sharee->getId(), 'write' => 'true']);
+        $this->assertResponseRedirects('/calendars/'.$userId);
+
+        $client->request('GET', '/calendars/'.$userId.'/shares/'.$calendar->getCalendar()->getId());
+        $this->assertResponseIsSuccessful();
+        $shares = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(1, $shares);
+        $this->assertSame(Principal::PREFIX.'test_user2', $shares[0]['principalUri']);
+        $this->assertTrue($shares[0]['isWriteAccess']);
+
+        $this->postAdmin($client, $shares[0]['revokeUrl']);
+        $this->assertResponseRedirects('/calendars/'.$userId);
+
+        $client->request('GET', '/calendars/'.$userId.'/shares/'.$calendar->getCalendar()->getId());
+        $this->assertSame([], json_decode($client->getResponse()->getContent(), true));
+    }
+
+    public function testStateChangingRoutesRejectGet(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
+
+        foreach ([
+            '/calendars/'.$userId.'/delete/'.$calendar->getId(),
+            '/calendars/'.$userId.'/revoke/'.$calendar->getId(),
+            '/calendars/'.$userId.'/share/'.$calendar->getId().'?principalId=1&write=true',
+        ] as $url) {
+            $client->request('GET', $url);
+            $this->assertResponseStatusCodeSame(405, 'GET '.$url.' must not be allowed');
+        }
+
+        $this->assertNotNull($calendarRepository->find($calendar->getId()));
+    }
+
+    public function testCalendarDeleteRejectsInvalidCsrfToken(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+        $calendarRepository = static::getContainer()->get(CalendarInstanceRepository::class);
+        $calendar = $calendarRepository->findOneByDisplayName('default.calendar.title');
+
+        $client->request('POST', '/calendars/'.$userId.'/delete/'.$calendar->getId(), ['_token' => 'not-the-token']);
+        $this->assertResponseStatusCodeSame(403);
+
+        $this->assertNotNull($calendarRepository->find($calendar->getId()));
     }
 }

--- a/tests/Functional/Controllers/UserControllerTest.php
+++ b/tests/Functional/Controllers/UserControllerTest.php
@@ -212,4 +212,20 @@ class UserControllerTest extends WebTestCase
 
         $this->assertNotNull(static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(User::class)->findOneByUsername('test_user'));
     }
+
+    public function testDelegateRemoveThroughAnotherUsersProxyIs404(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+        $principalRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class);
+        $delegate = $principalRepository->findOneByUri(Principal::PREFIX.'test_user2');
+        $foreignProxy = $principalRepository->findOneByUri(Principal::PREFIX.'test_user2'.Principal::READ_PROXY_SUFFIX);
+
+        $this->postAdmin($client, '/users/delegates/'.$userId.'/remove/'.$foreignProxy->getId().'/'.$delegate->getId());
+        $this->assertResponseStatusCodeSame(404);
+    }
 }

--- a/tests/Functional/Controllers/UserControllerTest.php
+++ b/tests/Functional/Controllers/UserControllerTest.php
@@ -2,12 +2,15 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\Principal;
 use App\Entity\User;
 use App\Security\AdminUser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class UserControllerTest extends WebTestCase
 {
+    use AdminPostTrait;
+
     private function getUserId($client, string $username): int
     {
         $userRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(User::class);
@@ -98,14 +101,14 @@ class UserControllerTest extends WebTestCase
         $userId1 = $this->getUserId($client, 'test_user');
         $userId2 = $this->getUserId($client, 'test_user2');
 
-        $client->request('GET', '/users/delete/'.$userId1);
+        $this->postAdmin($client, '/users/delete/'.$userId1);
 
         $this->assertResponseRedirects('/users/');
         $client->followRedirect();
 
         $this->assertAnySelectorTextContains('h5', 'Test User 2');
 
-        $client->request('GET', '/users/delete/'.$userId2);
+        $this->postAdmin($client, '/users/delete/'.$userId2);
 
         $this->assertResponseRedirects('/users/');
         $client->followRedirect();
@@ -130,9 +133,9 @@ class UserControllerTest extends WebTestCase
         $this->assertSelectorTextContains('h1', 'Delegates for Test User');
         $this->assertSelectorTextContains('a.btn', '+ Add a delegate');
         $this->assertAnySelectorTextContains('div', 'Delegation is enabled for this account.');
-        $this->assertAnySelectorTextContains('a.btn', 'Disable it');
+        $this->assertAnySelectorTextContains('button.btn', 'Disable it');
 
-        $client->clickLink('Disable it');
+        $client->submitForm('Disable it');
 
         $this->assertResponseRedirects('/users/delegates/'.$userId);
         $client->followRedirect();
@@ -141,6 +144,72 @@ class UserControllerTest extends WebTestCase
         $this->assertSelectorTextContains('h1', 'Delegates for Test User');
         $this->assertSelectorTextNotContains('a.btn', '+ Add a delegate');
         $this->assertAnySelectorTextContains('div', 'Delegation is not enabled for this account.');
-        $this->assertAnySelectorTextContains('a.btn', 'Enable it');
+        $this->assertAnySelectorTextContains('button.btn', 'Enable it');
+    }
+
+    public function testUserDelegateAddAndRemove(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+        $principalRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(Principal::class);
+        $delegate = $principalRepository->findOneByUri(Principal::PREFIX.'test_user2');
+        $writeProxy = $principalRepository->findOneByUri(Principal::PREFIX.'test_user'.Principal::WRITE_PROXY_SUFFIX);
+
+        $this->postAdmin($client, '/users/delegates/'.$userId.'/add', ['principalId' => $delegate->getId(), 'write' => 'true']);
+
+        $this->assertResponseRedirects('/users/delegates/'.$userId);
+        $client->followRedirect();
+        $this->assertAnySelectorTextContains('h5', 'Test User 2');
+
+        $this->postAdmin($client, '/users/delegates/'.$userId.'/remove/'.$writeProxy->getId().'/'.$delegate->getId());
+
+        $this->assertResponseRedirects('/users/delegates/'.$userId);
+        $client->followRedirect();
+        $this->assertSelectorTextNotContains('h5', 'Test User 2');
+    }
+
+    public function testStateChangingRoutesRejectGet(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+
+        foreach ([
+            '/users/delete/'.$userId,
+            '/users/delegation/'.$userId.'/off',
+            '/users/delegates/'.$userId.'/add?principalId=1&write=true',
+            '/users/delegates/'.$userId.'/remove/1/2',
+        ] as $url) {
+            $client->request('GET', $url);
+            $this->assertResponseStatusCodeSame(405, 'GET '.$url.' must not be allowed');
+        }
+
+        // Nothing was deleted
+        $this->assertNotNull(static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(User::class)->findOneByUsername('test_user'));
+    }
+
+    public function testUserDeleteRejectsInvalidCsrfToken(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+
+        $client->request('POST', '/users/delete/'.$userId, ['_token' => 'not-the-token']);
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->request('POST', '/users/delete/'.$userId);
+        $this->assertResponseStatusCodeSame(403);
+
+        $this->assertNotNull(static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(User::class)->findOneByUsername('test_user'));
     }
 }

--- a/tests/Functional/DavTest.php
+++ b/tests/Functional/DavTest.php
@@ -2,25 +2,92 @@
 
 namespace App\Tests\Functional;
 
+use App\Entity\CalendarInstance;
+use App\Entity\CalendarObject;
+use App\Entity\Principal;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 
 class DavTest extends WebTestCase
 {
+    private const SECRET_OBJECT_URI = 'secret.ics';
+    private const SECRET_SUMMARY = 'Top secret meeting';
+    private const SECRET_OBJECT_PATH = '/dav/calendars/test_user/default/'.self::SECRET_OBJECT_URI;
+
+    private const SECRET_CALENDAR_DATA = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Davis//Test//EN\r\nBEGIN:VEVENT\r\nUID:secret-1\r\nDTSTAMP:20260101T100000Z\r\nDTSTART:20260101T100000Z\r\nDTEND:20260101T110000Z\r\nSUMMARY:".self::SECRET_SUMMARY."\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
     /**
      * The DAVController uses a sabre/dav that relies on REQUEST_URI and REQUEST_METHOD
      * which are not set by default by PHPUnit (or to the wrong values).
      * We thus force them here so that the request looks like a real one for PHPUnit.
+     *
+     * The Authorization header is read by sabre/dav from $_SERVER too, so we set (or unset)
+     * it the same way.
      */
-    public static function requestDavClient(string $method, string $path): AbstractBrowser
+    public static function requestDav(AbstractBrowser $client, string $method, string $path, ?string $basicAuthUserPass = null): void
     {
         $_SERVER['REQUEST_URI'] = $path;
         $_SERVER['REQUEST_METHOD'] = $method;
 
-        $client = static::createClient();
+        if (null !== $basicAuthUserPass) {
+            $_SERVER['HTTP_AUTHORIZATION'] = 'Basic '.base64_encode($basicAuthUserPass);
+        } else {
+            unset($_SERVER['HTTP_AUTHORIZATION']);
+        }
+
         $client->request($method, $path);
+    }
+
+    public static function requestDavClient(string $method, string $path): AbstractBrowser
+    {
+        $client = static::createClient();
+        static::requestDav($client, $method, $path);
 
         return $client;
+    }
+
+    /**
+     * Stores a calendar object in test_user's default calendar directly in the database,
+     * bypassing the DAV server (the test client cannot feed a request body to sabre/dav).
+     */
+    private function createSecretCalendarObject(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $instance = $em->getRepository(CalendarInstance::class)->findOneBy([
+            'principalUri' => Principal::PREFIX.'test_user',
+            'uri' => 'default',
+        ]);
+        $this->assertNotNull($instance, 'Fixture calendar for test_user is missing');
+
+        $object = (new CalendarObject())
+            ->setCalendar($instance->getCalendar())
+            ->setUri(self::SECRET_OBJECT_URI)
+            ->setCalendarData(self::SECRET_CALENDAR_DATA)
+            ->setEtag(md5(self::SECRET_CALENDAR_DATA))
+            ->setSize(strlen(self::SECRET_CALENDAR_DATA))
+            ->setComponentType('VEVENT')
+            ->setUid('secret-1')
+            ->setLastModified(time())
+            ->setFirstOccurence(strtotime('2026-01-01T10:00:00Z'))
+            ->setLastOccurence(strtotime('2026-01-01T11:00:00Z'));
+
+        $em->persist($object);
+        $em->flush();
+        $em->clear();
+    }
+
+    private function getSecretCalendarData(): ?string
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+
+        $object = $em->getRepository(CalendarObject::class)->findOneBy(['uri' => self::SECRET_OBJECT_URI]);
+
+        return $object?->getCalendarData();
     }
 
     public function testUnauthorized(): void
@@ -28,5 +95,94 @@ class DavTest extends WebTestCase
         $client = static::requestDavClient('GET', '/dav/');
 
         $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testAuthenticatedUserCanReadOwnCalendarObject(): void
+    {
+        $client = static::createClient();
+        $this->createSecretCalendarObject();
+
+        static::requestDav($client, 'GET', self::SECRET_OBJECT_PATH, 'test_user:password');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertStringContainsString(self::SECRET_SUMMARY, $client->getResponse()->getContent());
+    }
+
+    public function testAnonymousCannotReadCalendarObject(): void
+    {
+        $client = static::createClient();
+        $this->createSecretCalendarObject();
+
+        static::requestDav($client, 'GET', self::SECRET_OBJECT_PATH);
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertStringNotContainsString(self::SECRET_SUMMARY, $client->getResponse()->getContent());
+    }
+
+    /**
+     * Regression test: the ACL plugin used to skip all privilege checks whenever
+     * `sabreAction=asset` was present in the query string, for any method and any path.
+     */
+    public function testAssetQueryParameterDoesNotBypassReadAcl(): void
+    {
+        $client = static::createClient();
+        $this->createSecretCalendarObject();
+
+        static::requestDav($client, 'GET', self::SECRET_OBJECT_PATH.'?sabreAction=asset');
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertStringNotContainsString(self::SECRET_SUMMARY, $client->getResponse()->getContent());
+    }
+
+    /**
+     * For an authenticated user, sabre does not throw while collecting the GET headers,
+     * so without the fix the object of another user is streamed back.
+     */
+    public function testAssetQueryParameterDoesNotBypassReadAclForOtherUsers(): void
+    {
+        $client = static::createClient();
+        $this->createSecretCalendarObject();
+
+        static::requestDav($client, 'GET', self::SECRET_OBJECT_PATH.'?sabreAction=asset', 'test_user2:password2');
+
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertStringNotContainsString(self::SECRET_SUMMARY, $client->getResponse()->getContent());
+    }
+
+    public function testAssetQueryParameterDoesNotBypassWriteAcl(): void
+    {
+        $client = static::createClient();
+        $this->createSecretCalendarObject();
+
+        static::requestDav($client, 'PUT', self::SECRET_OBJECT_PATH.'?sabreAction=asset');
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertSame(self::SECRET_CALENDAR_DATA, $this->getSecretCalendarData(), 'The calendar object must not have been modified');
+    }
+
+    public function testAssetQueryParameterDoesNotBypassAclOnCollections(): void
+    {
+        $client = static::createClient();
+
+        static::requestDav($client, 'GET', '/dav/calendars/test_user/default/?sabreAction=asset&assetName=favicon.ico');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * The only legitimate use of the bypass: the browser plugin loads its assets from the
+     * server root, and they must be reachable anonymously for public calendar pages.
+     */
+    public function testBrowserAssetsAreServedAnonymouslyFromRoot(): void
+    {
+        $client = static::createClient();
+
+        static::requestDav($client, 'GET', '/dav/?sabreAction=asset&assetName=favicon.ico');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame(
+            file_get_contents(static::getContainer()->getParameter('kernel.project_dir').'/vendor/sabre/dav/lib/DAV/Browser/assets/favicon.ico'),
+            $client->getResponse()->getContent()
+        );
     }
 }

--- a/tests/Functional/DavTest.php
+++ b/tests/Functional/DavTest.php
@@ -97,6 +97,15 @@ class DavTest extends WebTestCase
         $this->assertResponseStatusCodeSame(401);
     }
 
+    public function testEmptyPasswordIsRejected(): void
+    {
+        $client = static::createClient();
+
+        static::requestDav($client, 'GET', '/dav/', 'test_user:');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
     public function testAuthenticatedUserCanReadOwnCalendarObject(): void
     {
         $client = static::createClient();

--- a/tests/Functional/Service/AuthBackendTest.php
+++ b/tests/Functional/Service/AuthBackendTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Services;
+
+use App\Services\AbstractAuth;
+use App\Services\BasicAuth;
+use App\Services\IMAPAuth;
+use App\Services\LDAPAuth;
+use Sabre\HTTP\Request;
+use Sabre\HTTP\Response;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AuthBackendTest extends KernelTestCase
+{
+    /**
+     * Runs the backend through sabre's public entry point (`check()`), exactly as the
+     * DAV server does, for a given `user:password` pair.
+     */
+    private static function check(AbstractAuth $backend, string $userPass): array
+    {
+        $request = new Request('PROPFIND', '/dav/', ['Authorization' => 'Basic '.base64_encode($userPass)]);
+
+        return $backend->check($request, new Response());
+    }
+
+    /**
+     * A backend that accepts everything, to prove the guard in AbstractAuth never lets
+     * an empty username or password reach the concrete backend.
+     */
+    private static function acceptAllBackend(): AbstractAuth
+    {
+        return new class extends AbstractAuth {
+            public array $seen = [];
+
+            protected function checkCredentials(string $username, string $password): bool
+            {
+                $this->seen[] = [$username, $password];
+
+                return true;
+            }
+        };
+    }
+
+    public function testEmptyPasswordNeverReachesTheBackend(): void
+    {
+        $backend = self::acceptAllBackend();
+
+        [$ok] = self::check($backend, 'test_user:');
+
+        $this->assertFalse($ok);
+        $this->assertSame([], $backend->seen);
+    }
+
+    public function testEmptyUsernameNeverReachesTheBackend(): void
+    {
+        $backend = self::acceptAllBackend();
+
+        [$ok] = self::check($backend, ':password');
+
+        $this->assertFalse($ok);
+        $this->assertSame([], $backend->seen);
+    }
+
+    public function testNonEmptyCredentialsAreDelegatedToTheBackend(): void
+    {
+        $backend = self::acceptAllBackend();
+
+        [$ok, $principal] = self::check($backend, 'test_user:pa:ss');
+
+        $this->assertTrue($ok);
+        $this->assertSame('principals/test_user', $principal);
+        $this->assertSame([['test_user', 'pa:ss']], $backend->seen);
+    }
+
+    public function testAllBackendsShareTheGuard(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+
+        foreach ([BasicAuth::class, IMAPAuth::class, LDAPAuth::class] as $class) {
+            $backend = $container->get($class);
+            $this->assertInstanceOf(AbstractAuth::class, $backend, $class.' must extend AbstractAuth');
+
+            [$ok] = self::check($backend, 'test_user:');
+            $this->assertFalse($ok, $class.' must reject an empty password');
+
+            [$ok] = self::check($backend, ':password');
+            $this->assertFalse($ok, $class.' must reject an empty username');
+        }
+    }
+
+    public function testBasicAuthStillAcceptsValidCredentials(): void
+    {
+        self::bootKernel();
+        $backend = static::getContainer()->get(BasicAuth::class);
+
+        [$ok, $principal] = self::check($backend, 'test_user:password');
+        $this->assertTrue($ok);
+        $this->assertSame('principals/test_user', $principal);
+
+        [$ok] = self::check($backend, 'test_user:wrong');
+        $this->assertFalse($ok);
+    }
+}


### PR DESCRIPTION
- 🔒 Fixed an ACL bypass in the DAV server: appending ?sabreAction=asset to a URL skipped every permission check, letting any authenticated user read other users' events, contacts and files, and letting anonymous clients overwrite existing objects. The shortcut is now limited to the browser plugin's assets on the DAV root
- 🔒 Empty passwords are now rejected by all authentication backends. With LDAP, an empty password was passed to ldap_bind, which some directories (notably Active Directory) treat as a successful anonymous bind, allowing a login as any user
- 🔒 Destructive actions in the admin dashboard are now protected against CSRF: deleting users, calendars and address books, sharing and revoking calendars, and managing delegates are now POST requests carrying a token, instead of plain GET links
- 🔒 The dashboard and the API now check that a calendar or address book belongs to the user in the URL before showing, editing, sharing or deleting it. Deleting a calendar that was shared with a user only removes that share and no longer touches the owner's calendar; a calendar can no longer be shared with its own owner
- 🐛 The API no longer deletes all of a user's subscriptions and inbox items when one calendar is deleted, and GET /api/v1/calendars/{userId} no longer fails for users who have a calendar subscription