### PR TITLE
Migration fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,13 @@ jobs:
           php bin/console doctrine:database:create --if-not-exists --env=test
           php bin/console doctrine:migrations:migrate --no-interaction --env=test
           php bin/console doctrine:schema:validate --env=test
+          # Full chain check: roll every migration back down, then all the way up again.
+          # Nothing else ever runs the down() methods, so a broken rollback (wrong column
+          # name, duplicated ALTER clause, invalid cast) stays invisible until an operator
+          # actually needs to roll back.
+          php bin/console doctrine:migrations:migrate first --no-interaction --env=test
+          php bin/console doctrine:migrations:migrate --no-interaction --env=test
+          php bin/console doctrine:schema:validate --env=test
 
       - name: Run migrations (PostgreSQL)
         if: matrix.database == 'postgresql'
@@ -209,12 +216,26 @@ jobs:
           php bin/console doctrine:database:create --if-not-exists --env=test
           php bin/console doctrine:migrations:migrate --no-interaction --env=test
           php bin/console doctrine:schema:validate --skip-sync --env=test
+          # Full chain check: roll every migration back down, then all the way up again.
+          # Nothing else ever runs the down() methods, so a broken rollback (wrong column
+          # name, duplicated ALTER clause, invalid cast) stays invisible until an operator
+          # actually needs to roll back.
+          php bin/console doctrine:migrations:migrate first --no-interaction --env=test
+          php bin/console doctrine:migrations:migrate --no-interaction --env=test
+          php bin/console doctrine:schema:validate --skip-sync --env=test
 
       - name: Run migrations (SQLite)
         if: matrix.database == 'sqlite'
         env:
           DATABASE_URL: sqlite:///%kernel.project_dir%/var/data_test.db
         run: |
+          php bin/console doctrine:migrations:migrate --no-interaction --env=test
+          php bin/console doctrine:schema:validate --skip-sync --env=test
+          # Full chain check: roll every migration back down, then all the way up again.
+          # Nothing else ever runs the down() methods, so a broken rollback (wrong column
+          # name, duplicated ALTER clause, invalid cast) stays invisible until an operator
+          # actually needs to roll back.
+          php bin/console doctrine:migrations:migrate first --no-interaction --env=test
           php bin/console doctrine:migrations:migrate --no-interaction --env=test
           php bin/console doctrine:schema:validate --skip-sync --env=test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,9 @@ jobs:
           php bin/console doctrine:database:create --if-not-exists --env=test
           php bin/console doctrine:migrations:migrate --no-interaction --env=test
           php bin/console doctrine:schema:validate --env=test
+          # An empty schema only proves the DDL is valid. Seed the kind of row a DAV client
+          # creates (optional columns left NULL) so the rollback is exercised against data too.
+          php bin/console dbal:run-sql "INSERT INTO addressbooks (principaluri, uri, synctoken) VALUES ('principals/ci', 'ci-rollback-probe', 1)" --env=test
           # Full chain check: roll every migration back down, then all the way up again.
           # Nothing else ever runs the down() methods, so a broken rollback (wrong column
           # name, duplicated ALTER clause, invalid cast) stays invisible until an operator
@@ -216,6 +219,9 @@ jobs:
           php bin/console doctrine:database:create --if-not-exists --env=test
           php bin/console doctrine:migrations:migrate --no-interaction --env=test
           php bin/console doctrine:schema:validate --skip-sync --env=test
+          # An empty schema only proves the DDL is valid. Seed the kind of row a DAV client
+          # creates (optional columns left NULL) so the rollback is exercised against data too.
+          php bin/console dbal:run-sql "INSERT INTO addressbooks (id, principaluri, uri, synctoken) VALUES (nextval('addressbooks_id_seq'), 'principals/ci', 'ci-rollback-probe', 1)" --env=test
           # Full chain check: roll every migration back down, then all the way up again.
           # Nothing else ever runs the down() methods, so a broken rollback (wrong column
           # name, duplicated ALTER clause, invalid cast) stays invisible until an operator
@@ -231,6 +237,9 @@ jobs:
         run: |
           php bin/console doctrine:migrations:migrate --no-interaction --env=test
           php bin/console doctrine:schema:validate --skip-sync --env=test
+          # An empty schema only proves the DDL is valid. Seed the kind of row a DAV client
+          # creates (optional columns left NULL) so the rollback is exercised against data too.
+          php bin/console dbal:run-sql "INSERT INTO addressbooks (principaluri, uri, synctoken) VALUES ('principals/ci', 'ci-rollback-probe', 1)" --env=test
           # Full chain check: roll every migration back down, then all the way up again.
           # Nothing else ever runs the down() methods, so a broken rollback (wrong column
           # name, duplicated ALTER clause, invalid cast) stays invisible until an operator

--- a/migrations/Version20191202091507.php
+++ b/migrations/Version20191202091507.php
@@ -28,6 +28,8 @@ final class Version20191202091507 extends AbstractMigration
     {
         $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration is specific to \'mysql\'. Skipping it is fine.');
 
-        $this->addSql('ALTER TABLE calendarinstances CHANGE access access SMALLINT NOT NULL, CHANGE share_invitestatus share_invitestatus INT NOT NULL, CHANGE timezone timezone LONGTEXT DEFAULT NULL, CHANGE timezone timezone VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT \'NULL\' COLLATE `utf8mb4_unicode_ci`');
+        // NB: `timezone` is restored to its original VARCHAR(255); a VTIMEZONE blob longer than
+        // that would be rejected by MySQL rather than silently truncated.
+        $this->addSql('ALTER TABLE calendarinstances CHANGE access access SMALLINT NOT NULL, CHANGE share_invitestatus share_invitestatus INT NOT NULL, CHANGE timezone timezone VARCHAR(255) DEFAULT NULL');
     }
 }

--- a/migrations/Version20191203111729.php
+++ b/migrations/Version20191203111729.php
@@ -28,6 +28,9 @@ final class Version20191203111729 extends AbstractMigration
     {
         $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration is specific to \'mysql\'. Skipping it is fine.');
 
-        $this->addSql('ALTER TABLE addressbooks CHANGE description description LONGTEXT CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
+        // Since up() made the column nullable, address books created in the meantime may have
+        // no description at all; they would violate the restored NOT NULL.
+        $this->addSql("UPDATE addressbooks SET description = '' WHERE description IS NULL");
+        $this->addSql('ALTER TABLE addressbooks CHANGE description description LONGTEXT NOT NULL');
     }
 }

--- a/migrations/Version20231001214112.php
+++ b/migrations/Version20231001214112.php
@@ -30,8 +30,8 @@ final class Version20231001214112 extends AbstractMigration
     {
         $this->skipIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration is specific to \'postgresql\'. Skipping it is fine.');
 
-        $this->addSql("ALTER TABLE calendarobjects ALTER COLUMN calendardata TYPE BYTEA DEFAULT NULL USING convert_from(calendardata, 'utf8')");
-        $this->addSql("ALTER TABLE cards ALTER COLUMN carddata TYPE BYTEA DEFAULT NULL USING convert_from(carddata, 'utf8')");
-        $this->addSql("ALTER TABLE schedulingobjects ALTER COLUMN calendardata TYPE BYTEA DEFAULT NULL USING convert_from(calendardata, 'utf8')");
+        $this->addSql("ALTER TABLE calendarobjects ALTER COLUMN calendardata TYPE BYTEA USING convert_to(calendardata, 'utf8')");
+        $this->addSql("ALTER TABLE cards ALTER COLUMN carddata TYPE BYTEA USING convert_to(carddata, 'utf8')");
+        $this->addSql("ALTER TABLE schedulingobjects ALTER COLUMN calendardata TYPE BYTEA USING convert_to(calendardata, 'utf8')");
     }
 }

--- a/migrations/Version20260131161930.php
+++ b/migrations/Version20260131161930.php
@@ -44,9 +44,9 @@ final class Version20260131161930 extends AbstractMigration
 
         // Revert public = true back to ACCESS_PUBLIC (10)
         if ('postgresql' === $engine) {
-            $this->addSql('UPDATE calendarinstances SET access = 10 WHERE is_public = TRUE');
+            $this->addSql('UPDATE calendarinstances SET access = 10 WHERE public = TRUE');
         } else {
-            $this->addSql('UPDATE calendarinstances SET access = 10 WHERE is_public = 1');
+            $this->addSql('UPDATE calendarinstances SET access = 10 WHERE public = 1');
         }
 
         if ('mysql' === $engine) {

--- a/migrations/Version20260908210000.php
+++ b/migrations/Version20260908210000.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Give calendarsubscriptions.calendarorder a default value.
+ */
+final class Version20260908210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Default calendarsubscriptions.calendarorder to 0, as sabre/dav omits the column when a client subscribes without a calendar-order';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $engine = $this->connection->getDatabasePlatform()->getName();
+
+        // \Sabre\CalDAV\Backend\PDO::createSubscription() only lists `calendarorder` in its
+        // INSERT when the client sent {http://apple.com/ns/ical/}calendar-order. Without a
+        // default, subscribing to a feed then fails with a NOT NULL violation (HTTP 500).
+        if ('mysql' === $engine) {
+            $this->addSql('ALTER TABLE calendarsubscriptions CHANGE calendarorder calendarorder INT DEFAULT 0 NOT NULL');
+        } elseif ('postgresql' === $engine) {
+            $this->addSql('ALTER TABLE calendarsubscriptions ALTER COLUMN calendarorder SET DEFAULT 0');
+        } elseif ('sqlite' === $engine) {
+            // SQLite cannot alter a column in place: add the replacement, copy, swap, drop.
+            $this->addSql('ALTER TABLE calendarsubscriptions ADD COLUMN new_calendarorder INTEGER DEFAULT 0 NOT NULL');
+            $this->addSql('UPDATE calendarsubscriptions SET new_calendarorder = calendarorder');
+            $this->addSql('ALTER TABLE calendarsubscriptions RENAME COLUMN calendarorder TO old_calendarorder');
+            $this->addSql('ALTER TABLE calendarsubscriptions RENAME COLUMN new_calendarorder TO calendarorder');
+            $this->addSql('ALTER TABLE calendarsubscriptions DROP COLUMN old_calendarorder');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $engine = $this->connection->getDatabasePlatform()->getName();
+
+        if ('mysql' === $engine) {
+            $this->addSql('ALTER TABLE calendarsubscriptions CHANGE calendarorder calendarorder INT NOT NULL');
+        } elseif ('postgresql' === $engine) {
+            $this->addSql('ALTER TABLE calendarsubscriptions ALTER COLUMN calendarorder DROP DEFAULT');
+        } elseif ('sqlite' === $engine) {
+            // SQLite refuses to ADD a NOT NULL column without a default, so the only way back
+            // is to rebuild the table with its original definition.
+            $this->addSql('CREATE TABLE calendarsubscriptions_old (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, uri VARCHAR(255) NOT NULL, principaluri VARCHAR(255) NOT NULL, source CLOB DEFAULT NULL, displayname VARCHAR(255) DEFAULT NULL, refreshrate VARCHAR(10) DEFAULT NULL, calendarorder INTEGER NOT NULL, calendarcolor VARCHAR(10) DEFAULT NULL, striptodos SMALLINT DEFAULT NULL, stripalarms SMALLINT DEFAULT NULL, stripattachments SMALLINT DEFAULT NULL, lastmodified INTEGER DEFAULT NULL)');
+            $this->addSql('INSERT INTO calendarsubscriptions_old (id, uri, principaluri, source, displayname, refreshrate, calendarorder, calendarcolor, striptodos, stripalarms, stripattachments, lastmodified) SELECT id, uri, principaluri, source, displayname, refreshrate, calendarorder, calendarcolor, striptodos, stripalarms, stripattachments, lastmodified FROM calendarsubscriptions');
+            $this->addSql('DROP TABLE calendarsubscriptions');
+            $this->addSql('ALTER TABLE calendarsubscriptions_old RENAME TO calendarsubscriptions');
+        }
+    }
+}

--- a/migrations/Version20260908220000.php
+++ b/migrations/Version20260908220000.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Allow addressbooks.displayname to be null.
+ */
+final class Version20260908220000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow addressbooks.displayname to be null, as a display name is optional when a client creates an address book';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $engine = $this->connection->getDatabasePlatform()->getName();
+
+        // A display name is optional in CardDAV: \Sabre\CardDAV\Backend\PDO::createAddressBook()
+        // binds NULL when the client's MKCOL carries no {DAV:}displayname, and updateAddressBook()
+        // does the same when a PROPPATCH removes it. With a NOT NULL column both fail (HTTP 500).
+        if ('mysql' === $engine) {
+            $this->addSql('ALTER TABLE addressbooks CHANGE displayname displayname VARCHAR(255) DEFAULT NULL');
+        } elseif ('postgresql' === $engine) {
+            $this->addSql('ALTER TABLE addressbooks ALTER COLUMN displayname DROP NOT NULL');
+        } elseif ('sqlite' === $engine) {
+            // SQLite cannot alter a column in place: add the replacement, copy, swap, drop.
+            $this->addSql('ALTER TABLE addressbooks ADD COLUMN new_displayname VARCHAR(255) DEFAULT NULL');
+            $this->addSql('UPDATE addressbooks SET new_displayname = displayname');
+            $this->addSql('ALTER TABLE addressbooks RENAME COLUMN displayname TO old_displayname');
+            $this->addSql('ALTER TABLE addressbooks RENAME COLUMN new_displayname TO displayname');
+            $this->addSql('ALTER TABLE addressbooks DROP COLUMN old_displayname');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $engine = $this->connection->getDatabasePlatform()->getName();
+
+        // Address books created without a display name would violate the restored NOT NULL,
+        // so fall back to their uri rather than losing the row.
+        $this->addSql('UPDATE addressbooks SET displayname = uri WHERE displayname IS NULL');
+
+        if ('mysql' === $engine) {
+            $this->addSql('ALTER TABLE addressbooks CHANGE displayname displayname VARCHAR(255) NOT NULL');
+        } elseif ('postgresql' === $engine) {
+            $this->addSql('ALTER TABLE addressbooks ALTER COLUMN displayname SET NOT NULL');
+        } elseif ('sqlite' === $engine) {
+            // SQLite refuses to ADD a NOT NULL column without a default, so rebuild the table.
+            $this->addSql('CREATE TABLE addressbooks_old (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, principaluri VARCHAR(255) NOT NULL, displayname VARCHAR(255) NOT NULL, uri VARCHAR(255) NOT NULL, description CLOB DEFAULT NULL, synctoken VARCHAR(255) NOT NULL, included_in_birthday_calendar INTEGER DEFAULT 0)');
+            $this->addSql('INSERT INTO addressbooks_old (id, principaluri, displayname, uri, description, synctoken, included_in_birthday_calendar) SELECT id, principaluri, displayname, uri, description, synctoken, included_in_birthday_calendar FROM addressbooks');
+            $this->addSql('DROP TABLE addressbooks');
+            $this->addSql('ALTER TABLE addressbooks_old RENAME TO addressbooks');
+        }
+    }
+}

--- a/src/Entity/AddressBook.php
+++ b/src/Entity/AddressBook.php
@@ -21,7 +21,7 @@ class AddressBook
     #[ORM\Column(name: 'principaluri', type: 'string', length: 255)]
     private $principalUri;
 
-    #[ORM\Column(name: 'displayname', type: 'string', length: 255)]
+    #[ORM\Column(name: 'displayname', type: 'string', length: 255, nullable: true)]
     private $displayName;
 
     #[ORM\Column(type: 'string', length: 255)]
@@ -73,7 +73,7 @@ class AddressBook
         return $this->displayName;
     }
 
-    public function setDisplayName(string $displayName): self
+    public function setDisplayName(?string $displayName): self
     {
         $this->displayName = $displayName;
 

--- a/src/Entity/CalendarSubscription.php
+++ b/src/Entity/CalendarSubscription.php
@@ -28,8 +28,8 @@ class CalendarSubscription
     #[ORM\Column(name: 'refreshrate', type: 'string', length: 10, nullable: true)]
     private $refreshRate;
 
-    #[ORM\Column(name: 'calendarorder', type: 'integer')]
-    private $calendarOrder;
+    #[ORM\Column(name: 'calendarorder', type: 'integer', options: ['default' => 0])]
+    private $calendarOrder = 0;
 
     #[ORM\Column(name: 'calendarcolor', type: 'string', length: 10, nullable: true)]
     private $calendarColor;

--- a/src/Form/AddressBookType.php
+++ b/src/Form/AddressBookType.php
@@ -24,6 +24,8 @@ class AddressBookType extends AbstractType
             ->add('displayName', TextType::class, [
                 'label' => 'form.displayName',
                 'help' => 'form.name.help.carddav',
+                // Optional in CardDAV: clients may create an address book without one
+                'required' => false,
             ])
             ->add('includedInBirthdayCalendar', ChoiceType::class, [
                 'label' => 'form.includedInBirthdayCalendar',

--- a/templates/addressbooks/edit.html.twig
+++ b/templates/addressbooks/edit.html.twig
@@ -6,7 +6,7 @@
 {% include '_partials/back_button.html.twig' with { url: path('addressbook_index', {userId: userId}), text: "addressbooks.back"|trans({'user': principal.displayName }) } %}
 
 {% if addressbook.id %}
-<h1 class="display-4 fw-lighter mb-5">{{ "addressbooks.edit"|trans({'name': addressbook.displayName }) }}</h1>
+<h1 class="display-4 fw-lighter mb-5">{{ "addressbooks.edit"|trans({'name': addressbook.displayName ?? addressbook.uri }) }}</h1>
 {% else %}
 <h1 class="display-4 fw-lighter mb-5">{{ "addressbooks.new"|trans }} <small class="text-muted">for {{ principal.displayName }}</small></h1>
 {% endif %}

--- a/templates/addressbooks/index.html.twig
+++ b/templates/addressbooks/index.html.twig
@@ -11,7 +11,7 @@
 {% for addressbook in addressbooks %}
     <div class="list-group-item p-3">
         <div class="d-flex w-100 justify-content-between">
-            <h5 class="mb-1 me-auto">{{ addressbook.displayName }}</h5>
+            <h5 class="mb-1 me-auto">{{ addressbook.displayName ?? addressbook.uri }}</h5>
             <div class="me-0 text-right d-md-block d-none">
                 <a href="{{ path('addressbook_edit',{userId: userId, id: addressbook.id})}}" class="btn btn-sm btn-outline-primary ms-1">✎ {{ "edit"|trans }}</a>
                 <a href="#"

--- a/tests/Functional/AddressBookDavTest.php
+++ b/tests/Functional/AddressBookDavTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sabre\CardDAV\Backend\PDO as CardDavBackend;
+use Sabre\DAV\PropPatch;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AddressBookDavTest extends KernelTestCase
+{
+    private const PRINCIPAL = 'principals/test_user';
+
+    private EntityManagerInterface $em;
+    private CardDavBackend $backend;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->backend = new CardDavBackend($this->em->getConnection()->getNativeConnection());
+
+        $this->em->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->em->getConnection()->rollBack();
+        parent::tearDown();
+    }
+
+    private function addressBookFor(string $uri): array
+    {
+        foreach ($this->backend->getAddressBooksForUser(self::PRINCIPAL) as $book) {
+            if ($uri === $book['uri']) {
+                return $book;
+            }
+        }
+
+        $this->fail(sprintf('No address book found for uri "%s"', $uri));
+    }
+
+    /**
+     * Regression test for issue #275: a display name is optional in CardDAV, but the column
+     * was NOT NULL, so an MKCOL without {DAV:}displayname failed with a 500.
+     */
+    public function testAddressBookCanBeCreatedWithoutADisplayName(): void
+    {
+        $this->backend->createAddressBook(self::PRINCIPAL, 'nameless', []);
+
+        $this->assertNull($this->addressBookFor('nameless')['{DAV:}displayname']);
+    }
+
+    public function testADisplayNameIsStillStoredWhenGiven(): void
+    {
+        $this->backend->createAddressBook(self::PRINCIPAL, 'named', ['{DAV:}displayname' => 'My contacts']);
+
+        $this->assertSame('My contacts', $this->addressBookFor('named')['{DAV:}displayname']);
+    }
+
+    /**
+     * Same column, the other way round: a client may remove the display name with a PROPPATCH.
+     */
+    public function testADisplayNameCanBeRemovedAgain(): void
+    {
+        $id = $this->backend->createAddressBook(self::PRINCIPAL, 'transient', ['{DAV:}displayname' => 'Temporary']);
+
+        $propPatch = new PropPatch(['{DAV:}displayname' => null]);
+        $this->backend->updateAddressBook($id, $propPatch);
+
+        $this->assertTrue($propPatch->commit(), 'The PROPPATCH should succeed');
+        $this->assertNull($this->addressBookFor('transient')['{DAV:}displayname']);
+    }
+}

--- a/tests/Functional/CalendarSubscriptionTest.php
+++ b/tests/Functional/CalendarSubscriptionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sabre\CalDAV\Backend\PDO as CalendarBackend;
+use Sabre\DAV\Xml\Property\Href;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CalendarSubscriptionTest extends KernelTestCase
+{
+    private const PRINCIPAL = 'principals/test_user';
+    private const SOURCE = 'https://example.org/holidays.ics';
+
+    private EntityManagerInterface $em;
+    private CalendarBackend $backend;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->backend = new CalendarBackend($this->em->getConnection()->getNativeConnection());
+
+        $this->em->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->em->getConnection()->rollBack();
+        parent::tearDown();
+    }
+
+    private function subscriptionFor(string $uri): array
+    {
+        foreach ($this->backend->getSubscriptionsForUser(self::PRINCIPAL) as $subscription) {
+            if ($uri === $subscription['uri']) {
+                return $subscription;
+            }
+        }
+
+        $this->fail(sprintf('No subscription found for uri "%s"', $uri));
+    }
+
+    /**
+     * Regression test: `calendarorder` had no default, and sabre only lists it in its INSERT
+     * when the client sent {http://apple.com/ns/ical/}calendar-order. Subscribing without one
+     * therefore failed with a NOT NULL violation.
+     */
+    public function testSubscriptionCanBeCreatedWithoutACalendarOrder(): void
+    {
+        $this->backend->createSubscription(self::PRINCIPAL, 'holidays', [
+            '{http://calendarserver.org/ns/}source' => new Href(self::SOURCE),
+        ]);
+
+        $subscription = $this->subscriptionFor('holidays');
+
+        $this->assertSame(self::SOURCE, $subscription['source']);
+        $this->assertSame(0, (int) $subscription['{http://apple.com/ns/ical/}calendar-order']);
+    }
+
+    public function testAnExplicitCalendarOrderIsStillHonoured(): void
+    {
+        $this->backend->createSubscription(self::PRINCIPAL, 'ordered', [
+            '{http://calendarserver.org/ns/}source' => new Href(self::SOURCE),
+            '{http://apple.com/ns/ical/}calendar-order' => 3,
+        ]);
+
+        $this->assertSame(3, (int) $this->subscriptionFor('ordered')['{http://apple.com/ns/ical/}calendar-order']);
+    }
+}

--- a/tests/Functional/Controllers/AddressBookControllerTest.php
+++ b/tests/Functional/Controllers/AddressBookControllerTest.php
@@ -183,4 +183,27 @@ class AddressBookControllerTest extends WebTestCase
         $addressbookRepository = static::getContainer()->get('doctrine.orm.entity_manager')->getRepository(AddressBook::class);
         $this->assertNull($addressbookRepository->findOneBy(['uri' => 'hijack']));
     }
+
+    public function testAddressBookWithoutADisplayNameFallsBackToItsUri(): void
+    {
+        $user = new AdminUser('admin', 'test');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $userId = $this->getUserId($client, 'test_user');
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $nameless = (new AddressBook())
+            ->setPrincipalUri('principals/test_user')
+            ->setUri('nameless-book')
+            ->setDisplayName(null);
+        $em->persist($nameless);
+        $em->flush();
+
+        $client->request('GET', '/addressbooks/'.$userId);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertAnySelectorTextContains('h5', 'nameless-book');
+    }
 }


### PR DESCRIPTION
Fix migrations: two schema bugs and four broken rollbacks

  - Address books can now be created without a display name (fixes #275). A display name is optional in CardDAV, but addressbooks.displayname was NOT NULL, so an MKCOL without one, or a PROPPATCH removing it, returned a 500. The column is nullable now, the admin form no longer requires it, and the two places that print it fall back to the URI.
  - Subscribing to a calendar feed no longer fails. calendarsubscriptions.calendarorder was NOT NULL with no default, and sabre omits the column unless the client sends a calendar-order. It now defaults to 0, as in sabre's reference schema.
  - Version20260131161930 rollback filtered on is_public; the column is called public.
  - Version20191202091507 rollback (MySQL) had two CHANGE timezone timezone clauses in one ALTER, which MySQL rejects, plus a bogus DEFAULT 'NULL' string.
  - Version20231001214112 rollback (PostgreSQL) used an inline DEFAULT that Postgres rejects in ALTER COLUMN ... TYPE, with convert_from() casting the wrong way.
  - Version20191203111729 rollback (MySQL) restored description NOT NULL without clearing NULLs, which every client-created address book has.
  - CI now runs the full chain per driver: migrate up, validate, roll all the way down, up again, validate. It also seeds a row with optional columns left NULL, as an MKCOL produces, since an empty schema only proves the DDL parses. Nothing had ever executed a down(), which is why all four bugs survived.
  - Seven new tests covering create without a name, explicit name kept, PROPPATCH removal, the admin fallback, and subscribing with and without an order.
